### PR TITLE
fixed tag wrapping issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
 ## What this PR does, and why
 
-> Add an explanation of what the code in this PR does, add screenshot/screencapture where necessary.
+> Add an explanation of what the code in this PR does. Add screenshot/screencapture and jira link where necessary.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,3 @@
-## What it does, and why
+## What this PR does, and why
 
-> Add a thorough explanation of what the code in this PR does in this section.
-
-## Checklist
-
-> Please go through following checklist before requesting review and fix issues listed there. If your code touches the files with the below in question, please address them.
-
-#### Workflow
-
-- [ ] Are you writing documentation/comments for the bits of code with complex changes?
-- [ ] Are you writing tests (Storybook/Unit testing)
-
-## Jira Tickets
-
-> If this PR implements changes related to one or more Jira tickets please add them here:
-
-## UI Changes
-
-> If this PR introduce some interaction or animation change please also add GIF with how it behaves. Don't forget that this change should be possible to simulate in storybook.
-> You can use [this tool](http://gifbrewery.com/) to record your screen and convert it to a GIF.
+> Add an explanation of what the code in this PR does, add screenshot/screencapture where necessary.

--- a/lib/components/Modal/index.js
+++ b/lib/components/Modal/index.js
@@ -194,7 +194,7 @@ const Modal = ({
         >
           {headerContent ? (
             <HeaderContent>
-              <Box mr="l" width="100%">
+              <Box mr="xl" width="100%">
                 {headerContent}
               </Box>
               <CloseButton

--- a/lib/components/Tag/index.js
+++ b/lib/components/Tag/index.js
@@ -94,6 +94,8 @@ const TagValueText = styled.div`
   max-width: 40ch;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: normal;
+  text-align: left;
 `;
 
 const TagEdit = styled(TagValue)`


### PR DESCRIPTION
## What it does, and why

Fixes an issue with long tags breaking the layout, they will now wrap correctly if they don't fit into parent container width.

<img width="575" alt="Screenshot 2023-02-09 at 4 46 27 pm" src="https://user-images.githubusercontent.com/29616429/217964136-4371ad6e-6776-4365-a165-1cf9f96adff7.png">