### PR TITLE
Tpp 365 move component when hidden

### DIFF
--- a/lib/components/ActionsMenu/ActionsMenu.mdx
+++ b/lib/components/ActionsMenu/ActionsMenu.mdx
@@ -51,6 +51,14 @@ An example of using ActionsMenu paired with a text button trigger.
   <Story id="components-actionsmenu--text-button-actions-menu" />
 </Preview>
 
+## Test Outside View
+
+An example of using ActionsMenu paired with a text button trigger.
+
+<Preview>
+  <Story id="components-actionsmenu--test-outside-view" />
+</Preview>
+
 ## Properties
 
 <Props of={ActionsMenu} />

--- a/lib/components/ActionsMenu/ActionsMenu.mdx
+++ b/lib/components/ActionsMenu/ActionsMenu.mdx
@@ -51,12 +51,12 @@ An example of using ActionsMenu paired with a text button trigger.
   <Story id="components-actionsmenu--text-button-actions-menu" />
 </Preview>
 
-## Test Outside View
+## Keep Actions Menu In View
 
-An example of using ActionsMenu paired with a text button trigger.
+Keeps the Actions Menu in view by changing the direction if it naturally falls out of view.
 
 <Preview>
-  <Story id="components-actionsmenu--test-outside-view" />
+  <Story id="components-actionsmenu--keep-in-view-example" />
 </Preview>
 
 ## Properties

--- a/lib/components/ActionsMenu/ActionsMenu.stories.js
+++ b/lib/components/ActionsMenu/ActionsMenu.stories.js
@@ -323,8 +323,8 @@ export const textButtonActionsMenu = () => {
 textButtonActionsMenu.storyName = "Text Button Actions Menu";
 
 export const keepInViewExample = () => (
-  <Flex justifyContent="flex-end" width="100%">
-    <ActionsMenu direction="right">
+  <Flex alignItems="flex-end" width="100%" flexDirection="column">
+    <ActionsMenu direction="right" mb="r">
       <ActionsMenuItem href="https://orchestrated.io/">
         Open details page
       </ActionsMenuItem>
@@ -334,6 +334,23 @@ export const keepInViewExample = () => (
         </ActionsMenuItem>
       </BrowserRouter>
       <ActionsMenuItem onClick={action("clicked")}>Remove</ActionsMenuItem>
+    </ActionsMenu>
+    <ActionsMenu
+      direction="right"
+      menuTopPosition="30px"
+      menuLeftPosition="0"
+      menuWidth="220px"
+      customTriggerComponent={
+        <Button variant="ghost" type="button" iconRight small>
+          Contact via...
+          <Icon icon={["fas", "chevron-down"]} />
+        </Button>
+      }
+    >
+      <ActionsMenuItem href="#">Email</ActionsMenuItem>
+      <ActionsMenuItem href="#">Phone</ActionsMenuItem>
+      <ActionsMenuItem href="#">MS Teams</ActionsMenuItem>
+      <ActionsMenuItem href="#">Slack</ActionsMenuItem>
     </ActionsMenu>
   </Flex>
 );

--- a/lib/components/ActionsMenu/ActionsMenu.stories.js
+++ b/lib/components/ActionsMenu/ActionsMenu.stories.js
@@ -42,7 +42,7 @@ defaultActionsMenu.storyName = "Default";
 
 export const leftOffsetActionsMenu = () => (
   <Flex justifyContent="flex-end">
-    <ActionsMenu direction="right">
+    <ActionsMenu direction="left">
       <ActionsMenuItem href="https://orchestrated.io/">
         Open details page
       </ActionsMenuItem>

--- a/lib/components/ActionsMenu/ActionsMenu.stories.js
+++ b/lib/components/ActionsMenu/ActionsMenu.stories.js
@@ -322,7 +322,7 @@ export const textButtonActionsMenu = () => {
 
 textButtonActionsMenu.storyName = "Text Button Actions Menu";
 
-export const testOutsideView = () => (
+export const keepInViewExample = () => (
   <Flex justifyContent="flex-end" width="100%">
     <ActionsMenu direction="right">
       <ActionsMenuItem href="https://orchestrated.io/">
@@ -337,4 +337,4 @@ export const testOutsideView = () => (
     </ActionsMenu>
   </Flex>
 );
-testOutsideView.storyName = "Test Outside View";
+keepInViewExample.storyName = "Keep In View Example";

--- a/lib/components/ActionsMenu/ActionsMenu.stories.js
+++ b/lib/components/ActionsMenu/ActionsMenu.stories.js
@@ -42,7 +42,7 @@ defaultActionsMenu.storyName = "Default";
 
 export const leftOffsetActionsMenu = () => (
   <Flex justifyContent="flex-end">
-    <ActionsMenu direction="left">
+    <ActionsMenu direction="right">
       <ActionsMenuItem href="https://orchestrated.io/">
         Open details page
       </ActionsMenuItem>
@@ -321,3 +321,20 @@ export const textButtonActionsMenu = () => {
 };
 
 textButtonActionsMenu.storyName = "Text Button Actions Menu";
+
+export const testOutsideView = () => (
+  <Flex justifyContent="flex-end" width="100%">
+    <ActionsMenu direction="right">
+      <ActionsMenuItem href="https://orchestrated.io/">
+        Open details page
+      </ActionsMenuItem>
+      <BrowserRouter>
+        <ActionsMenuItem as={Link} to="/">
+          Edit
+        </ActionsMenuItem>
+      </BrowserRouter>
+      <ActionsMenuItem onClick={action("clicked")}>Remove</ActionsMenuItem>
+    </ActionsMenu>
+  </Flex>
+);
+testOutsideView.storyName = "Test Outside View";

--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -219,9 +219,7 @@ export const ActionsMenuBody = ({
 }) => {
   const [inViewDirection, setInViewDirection] = useState(direction);
   const [ref, setIsShown] = useKeepInView({
-    inViewOptions: { threshold: 1 },
     direction,
-    shown: true,
     callback: setInViewDirection
   });
   const onToggleInView = (e) => {

--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -220,7 +220,8 @@ export const ActionsMenuBody = ({
   const [inViewDirection, setInViewDirection] = useState(direction);
   const [ref, setIsShown] = useKeepInView({
     direction,
-    callback: setInViewDirection
+    callback: setInViewDirection,
+    shown: true
   });
   const onToggleInView = (e) => {
     setIsShown(!toggleState);

--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -3,6 +3,7 @@ import styled, { css, keyframes, ThemeProvider } from "styled-components";
 import PropTypes from "prop-types";
 import { space, layout } from "styled-system";
 import { themeGet } from "@styled-system/theme-get";
+import { useKeepInView } from "../../hooks/keepInView";
 
 const crossTransform1 = keyframes`
   0% {
@@ -216,14 +217,26 @@ export const ActionsMenuBody = ({
   children,
   ...props
 }) => {
+  const [inViewDirection, setInViewDirection] = useState(direction);
+  const [ref, setIsShown] = useKeepInView({
+    inViewOptions: { threshold: 1 },
+    direction,
+    shown: toggleState,
+    callback: setInViewDirection
+  });
+  const onToggleInView = (e) => {
+    setIsShown(!toggleState);
+    onToggle(e);
+  };
+
   let triggerBtn = null;
   if (customTriggerComponent) {
     triggerBtn = React.cloneElement(customTriggerComponent, {
-      onClick: onToggle
+      onClick: onToggleInView
     });
   } else {
     triggerBtn = (
-      <Control onClick={onToggle}>
+      <Control onClick={onToggleInView}>
         <Icon isOpen={toggleState} />
       </Control>
     );
@@ -234,11 +247,12 @@ export const ActionsMenuBody = ({
       {triggerBtn}
       <Menu
         isOpen={toggleState}
-        direction={direction}
+        direction={inViewDirection}
         menuTopPosition={menuTopPosition}
         menuLeftPosition={menuLeftPosition}
         menuRightPosition={menuRightPosition}
         menuWidth={menuWidth}
+        ref={ref}
       >
         {children}
       </Menu>

--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -221,7 +221,7 @@ export const ActionsMenuBody = ({
   const [ref, setIsShown] = useKeepInView({
     inViewOptions: { threshold: 1 },
     direction,
-    shown: toggleState,
+    shown: true,
     callback: setInViewDirection
   });
   const onToggleInView = (e) => {

--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -217,11 +217,31 @@ export const ActionsMenuBody = ({
   children,
   ...props
 }) => {
+  const [menuPosition] = useState({
+    menuLeftPosition,
+    menuRightPosition,
+    menuTopPosition
+  });
   const [inViewDirection, setInViewDirection] = useState(direction);
+
+  const setMenuPosition = (newDirection) => {
+    if (
+      typeof menuLeftPosition !== "undefined" ||
+      typeof menuRightPosition !== "undefined"
+    ) {
+      if (menuPosition.menuLeftPosition) {
+        menuPosition.menuRightPosition = menuPosition.menuLeftPosition;
+        menuPosition.menuLeftPosition = null;
+      } else if (menuPosition.menuRightPosition) {
+        menuPosition.menuLeftPosition = menuPosition.menuRightPosition;
+        menuPosition.menuRightPosition = null;
+      }
+    }
+    setInViewDirection(newDirection);
+  };
   const [ref, setIsShown] = useKeepInView({
     direction,
-    callback: setInViewDirection,
-    shown: true
+    callback: setMenuPosition
   });
   const onToggleInView = (e) => {
     setIsShown(!toggleState);
@@ -247,9 +267,9 @@ export const ActionsMenuBody = ({
       <Menu
         isOpen={toggleState}
         direction={inViewDirection}
-        menuTopPosition={menuTopPosition}
-        menuLeftPosition={menuLeftPosition}
-        menuRightPosition={menuRightPosition}
+        menuTopPosition={menuPosition.menuTopPosition}
+        menuLeftPosition={menuPosition.menuLeftPosition}
+        menuRightPosition={menuPosition.menuRightPosition}
         menuWidth={menuWidth}
         ref={ref}
       >

--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -1,4 +1,9 @@
-import React, { useState, useEffect, useImperativeHandle } from "react";
+import React, {
+  useState,
+  useEffect,
+  useImperativeHandle,
+  useCallback
+} from "react";
 import styled, { css, keyframes, ThemeProvider } from "styled-components";
 import PropTypes from "prop-types";
 import { space, layout } from "styled-system";
@@ -224,27 +229,30 @@ export const ActionsMenuBody = ({
   });
   const [inViewDirection, setInViewDirection] = useState(direction);
 
-  const setMenuPosition = (newDirection) => {
-    if (
-      typeof menuLeftPosition !== "undefined" ||
-      typeof menuRightPosition !== "undefined"
-    ) {
-      if (menuPosition.menuLeftPosition) {
-        menuPosition.menuRightPosition = menuPosition.menuLeftPosition;
-        menuPosition.menuLeftPosition = null;
-      } else if (menuPosition.menuRightPosition) {
-        menuPosition.menuLeftPosition = menuPosition.menuRightPosition;
-        menuPosition.menuRightPosition = null;
+  const setMenuPosition = useCallback(
+    (newDirection) => {
+      if (
+        typeof menuLeftPosition !== "undefined" ||
+        typeof menuRightPosition !== "undefined"
+      ) {
+        if (menuPosition.menuLeftPosition) {
+          menuPosition.menuRightPosition = menuPosition.menuLeftPosition;
+          menuPosition.menuLeftPosition = null;
+        } else if (menuPosition.menuRightPosition) {
+          menuPosition.menuLeftPosition = menuPosition.menuRightPosition;
+          menuPosition.menuRightPosition = null;
+        }
       }
-    }
-    setInViewDirection(newDirection);
-  };
-  const [ref, setIsShown] = useKeepInView({
+      setInViewDirection(newDirection);
+    },
+    [menuLeftPosition, menuRightPosition, menuPosition, setInViewDirection]
+  );
+  const [ref] = useKeepInView({
     direction,
-    callback: setMenuPosition
+    callback: setMenuPosition,
+    shown: true
   });
   const onToggleInView = (e) => {
-    setIsShown(!toggleState);
     onToggle(e);
   };
 

--- a/lib/components/Popover/Popover.mdx
+++ b/lib/components/Popover/Popover.mdx
@@ -61,6 +61,14 @@ Tooltip with link example
   <Story id="components-popover--tooltip-with-link-example" />
 </Preview>
 
+## Test Outside View
+
+This tests that the tooltip will always be visible. If it would fall outside the view port, the direction is changed to being it back into view. In this case the default is to right align the Popover but it must be left aligned to be visible.
+
+<Preview>
+  <Story id="components-popover--test-outside-view" />
+</Preview>
+
 ## Properties
 
 <Props of={Popover} />

--- a/lib/components/Popover/Popover.mdx
+++ b/lib/components/Popover/Popover.mdx
@@ -61,12 +61,12 @@ Tooltip with link example
   <Story id="components-popover--tooltip-with-link-example" />
 </Preview>
 
-## Test Outside View
+## Keep In View Example
 
-This tests that the tooltip will always be visible. If it would fall outside the view port, the direction is changed to being it back into view. In this case the default is to right align the Popover but it must be left aligned to be visible.
+If the tooltip falls outside the view port, the direction is changed to bring it back into view. In this case the default is to right align the Popover but it must be left aligned to be visible.
 
 <Preview>
-  <Story id="components-popover--test-outside-view" />
+  <Story id="components-popover--keep-in-view-example" />
 </Preview>
 
 ## Properties

--- a/lib/components/Popover/Popover.stories.js
+++ b/lib/components/Popover/Popover.stories.js
@@ -133,11 +133,11 @@ export const tooltipWithLinkExample = () => (
 );
 tooltipWithLinkExample.storyName = "Tooltip with link Example";
 
-export const testOutsideView = () => (
+export const keepInViewExample = () => (
   <Flex justifyContent="flex-end" width="100%">
     <Popover text="Description that explains child element">
       <Button>Hover Me!</Button>
     </Popover>
   </Flex>
 );
-testOutsideView.storyName = "Test Outside View";
+keepInViewExample.storyName = "Keep In View Example";

--- a/lib/components/Popover/Popover.stories.js
+++ b/lib/components/Popover/Popover.stories.js
@@ -132,3 +132,12 @@ export const tooltipWithLinkExample = () => (
   />
 );
 tooltipWithLinkExample.storyName = "Tooltip with link Example";
+
+export const testOutsideView = () => (
+  <Flex justifyContent="flex-end" width="100%">
+    <Popover text="Description that explains child element">
+      <Button>Hover Me!</Button>
+    </Popover>
+  </Flex>
+);
+testOutsideView.storyName = "Test Outside View";

--- a/lib/components/Popover/index.js
+++ b/lib/components/Popover/index.js
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import styled, { css, ThemeProvider } from "styled-components";
 import { space, layout } from "styled-system";
+import { useInView } from "react-intersection-observer";
+import { replace, includes } from "lodash";
 import Icon from "../Icon";
 import { themeGet } from "@styled-system/theme-get";
 
@@ -240,6 +242,28 @@ const Text = styled.div`
       : css``};
 `;
 
+const directions = [
+  "top",
+  "topRight",
+  "right",
+  "bottomRight",
+  "bottom",
+  "bottomLeft",
+  "left",
+  "topLeft"
+];
+
+const oppositeDirection = (direction) => {
+  if (!direction) return "left";
+  if (includes(direction, "top")) return replace(direction, "top", "bottom");
+  else if (includes(direction, "bottom"))
+    return replace(direction, "bottom", "top");
+  else if (includes(direction, "left"))
+    return replace(direction, "left", "right");
+  else if (includes(direction, "right"))
+    return replace(direction, "right", "left");
+};
+
 /**
  * This popover component is intended to be used to supplement buttons (or other elements) that require some helper text. It supports customisation of direction and width. This is so that you can ensure that the popover doesn't run off the screen, and that the width suits the amount of text in the popover.
  *
@@ -258,13 +282,26 @@ export default function Popover({
   enableSelectAll = true,
   ...props
 }) {
+  const [inViewDirection, setInViewDirection] = useState(direction);
+  const [isShown, setIsShown] = useState(false);
+  const { ref, inView } = useInView();
+  useEffect(() => {
+    if (!inView && isShown) setInViewDirection(oppositeDirection(direction));
+  }, [inView, direction, isShown]);
+
   const component = (
-    <Container inlineBlock={inlineBlock} {...props}>
+    <Container
+      inlineBlock={inlineBlock}
+      {...props}
+      onMouseEnter={() => setIsShown(true)}
+      onMouseLeave={() => setIsShown(false)}
+    >
       {!!text && (
         <Text
+          ref={ref}
           className="popoverText"
           textAlign={textAlign}
-          direction={direction}
+          direction={inViewDirection}
           width={width}
           enableSelectAll={enableSelectAll}
         >
@@ -291,16 +328,7 @@ Popover.propTypes = {
   /** The element that requires the popover helper text. */
   children: PropTypes.element,
   /** Specifies the direction of the popover. Defaults to right if not specified */
-  direction: PropTypes.oneOf([
-    "top",
-    "topRight",
-    "right",
-    "bottomRight",
-    "bottom",
-    "bottomLeft",
-    "left",
-    "topLeft"
-  ]),
+  direction: PropTypes.oneOf(directions),
   /** The text contained in the popover element */
   text: PropTypes.node,
   /** Specifies the alignment of the text inside the popover */

--- a/lib/components/Popover/index.js
+++ b/lib/components/Popover/index.js
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import styled, { css, ThemeProvider } from "styled-components";
 import { space, layout } from "styled-system";
-import { useInView } from "react-intersection-observer";
 import { keys } from "lodash";
 import Icon from "../Icon";
 import { themeGet } from "@styled-system/theme-get";
+import { useKeepInView, directions } from "../../hooks/keepInView";
 
 const Container = styled.div`
   ${space}
@@ -243,27 +243,6 @@ const Text = styled.div`
 `;
 
 /**
- * An explicit mapping of directions to their opposites
- * This is used in oppositeDirection() to move the Popover when it leaves the viewPort
- */
-const directions = {
-  top: "bottom",
-  topRight: "bottomLeft",
-  right: "left",
-  bottomRight: "topLeft",
-  bottom: "top",
-  bottomLeft: "topRight",
-  left: "right",
-  topLeft: "bottomRight"
-};
-
-const oppositeDirection = (direction) => {
-  console.log("???????????", direction);
-  if (!direction || !directions[direction]) return "left";
-  return directions[direction];
-};
-
-/**
  * This popover component is intended to be used to supplement buttons (or other elements) that require some helper text. It supports customisation of direction and width. This is so that you can ensure that the popover doesn't run off the screen, and that the width suits the amount of text in the popover.
  *
  * If you don't specify a width, 200px is the default, but as a general guide try and keep widths somewhere between 150-250 if you are modifying. Make sure if setting width you include the unit you want it to use, e.g. pixels, %.
@@ -282,11 +261,10 @@ export default function Popover({
   ...props
 }) {
   const [inViewDirection, setInViewDirection] = useState(direction);
-  const [isShown, setIsShown] = useState(false);
-  const { ref, inView } = useInView();
-  useEffect(() => {
-    if (!inView && isShown) setInViewDirection(oppositeDirection(direction));
-  }, [inView, direction, isShown]);
+  const [ref, setIsShown] = useKeepInView({
+    direction,
+    callback: setInViewDirection
+  });
 
   const component = (
     <Container

--- a/lib/components/Popover/index.js
+++ b/lib/components/Popover/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import styled, { css, ThemeProvider } from "styled-components";
 import { space, layout } from "styled-system";
 import { useInView } from "react-intersection-observer";
-import { replace, includes } from "lodash";
+import { keys } from "lodash";
 import Icon from "../Icon";
 import { themeGet } from "@styled-system/theme-get";
 
@@ -242,26 +242,25 @@ const Text = styled.div`
       : css``};
 `;
 
-const directions = [
-  "top",
-  "topRight",
-  "right",
-  "bottomRight",
-  "bottom",
-  "bottomLeft",
-  "left",
-  "topLeft"
-];
+/**
+ * An explicit mapping of directions to their opposites
+ * This is used in oppositeDirection() to move the Popover when it leaves the viewPort
+ */
+const directions = {
+  top: "bottom",
+  topRight: "bottomLeft",
+  right: "left",
+  bottomRight: "topLeft",
+  bottom: "top",
+  bottomLeft: "topRight",
+  left: "right",
+  topLeft: "bottomRight"
+};
 
 const oppositeDirection = (direction) => {
-  if (!direction) return "left";
-  if (includes(direction, "top")) return replace(direction, "top", "bottom");
-  else if (includes(direction, "bottom"))
-    return replace(direction, "bottom", "top");
-  else if (includes(direction, "left"))
-    return replace(direction, "left", "right");
-  else if (includes(direction, "right"))
-    return replace(direction, "right", "left");
+  console.log("???????????", direction);
+  if (!direction || !directions[direction]) return "left";
+  return directions[direction];
 };
 
 /**
@@ -328,7 +327,7 @@ Popover.propTypes = {
   /** The element that requires the popover helper text. */
   children: PropTypes.element,
   /** Specifies the direction of the popover. Defaults to right if not specified */
-  direction: PropTypes.oneOf(directions),
+  direction: PropTypes.oneOf(keys(directions)),
   /** The text contained in the popover element */
   text: PropTypes.node,
   /** Specifies the alignment of the text inside the popover */

--- a/lib/components/Popover/index.js
+++ b/lib/components/Popover/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import styled, { css, ThemeProvider } from "styled-components";
 import { space, layout } from "styled-system";

--- a/lib/hooks/keepInView.js
+++ b/lib/hooks/keepInView.js
@@ -45,10 +45,15 @@ export const useKeepInView = ({
   inViewOptions = { threshold: 1 },
   callback
 }) => {
+  const [lastDirection] = useState({ direction });
   const [isShown, setIsShown] = useState(shown);
   const { ref, inView } = useInView(inViewOptions);
   useEffect(() => {
-    if (!inView && isShown) callback(oppositeDirection(direction));
+    if (!inView && isShown) {
+      const newDirection = oppositeDirection(lastDirection.direction);
+      callback(newDirection);
+      lastDirection.direction = newDirection;
+    }
   }, [inView, direction, isShown, callback]);
 
   return [ref, setIsShown];

--- a/lib/hooks/keepInView.js
+++ b/lib/hooks/keepInView.js
@@ -47,11 +47,10 @@ export const useKeepInView = ({
   callback
 }) => {
   const [isShown, setIsShown] = useState(shown);
-  const { ref, inView, entry } = useInView(inViewOptions);
+  const { ref, inView } = useInView(inViewOptions);
   useEffect(() => {
-    console.log("!!!!!!!!!!!", direction, isShown, inView, entry);
     if (!inView && isShown) callback(oppositeDirection(direction));
-  }, [inView, direction, isShown, entry]);
+  }, [inView, direction, isShown]);
 
   return [ref, setIsShown];
 };

--- a/lib/hooks/keepInView.js
+++ b/lib/hooks/keepInView.js
@@ -1,0 +1,57 @@
+import { useState, useEffect } from "react";
+import { useInView } from "react-intersection-observer";
+
+/**
+ * An explicit mapping of directions to their opposites
+ * This is used in oppositeDirection() to move the Popover when it leaves the viewPort
+ */
+export const directions = {
+  top: "bottom",
+  topRight: "bottomLeft",
+  right: "left",
+  bottomRight: "topLeft",
+  bottom: "top",
+  bottomLeft: "topRight",
+  left: "right",
+  topLeft: "bottomRight"
+};
+
+export const oppositeDirection = (direction) => {
+  console.log("??????????????????", direction);
+  if (!direction || !directions[direction]) return "left";
+  return directions[direction];
+};
+
+/**
+ * This hook keeps track of the in view status of a component that has a direction setting, like a Popover or ActionsMenu.
+ *
+ * It does this by tracking the "in view" status of a component that has a direction property and then calling a specified
+ * callback with the exact opposite direction setting when it falls out of the view port.
+ *
+ * The hook returns a `ref` (see https://www.npmjs.com/package/react-intersection-observer) which must be set on the
+ * component that is beinbg tracked. It also returns a callback to be called when the component is made visible to the
+ * user. This is useful for Popovers where the direction must only be set on hover or on a mouse click for example. For
+ * components that are always visible set the default visibility prop to `true`.
+ *
+ * To use this hook pass in:
+ * - the initial direction setting
+ * - the default visibility of the component
+ * - the `useInView` options (see https://www.npmjs.com/package/react-intersection-observer)
+ * - a callback to change the direction of the component when it leaves the view port
+ *
+ */
+export const useKeepInView = ({
+  direction,
+  shown = false,
+  inViewOptions = {},
+  callback
+}) => {
+  const [isShown, setIsShown] = useState(shown);
+  const { ref, inView, entry } = useInView(inViewOptions);
+  useEffect(() => {
+    console.log("!!!!!!!!!!!", direction, isShown, inView, entry);
+    if (!inView && isShown) callback(oppositeDirection(direction));
+  }, [inView, direction, isShown, entry]);
+
+  return [ref, setIsShown];
+};

--- a/lib/hooks/keepInView.js
+++ b/lib/hooks/keepInView.js
@@ -42,7 +42,7 @@ export const oppositeDirection = (direction) => {
 export const useKeepInView = ({
   direction,
   shown = false,
-  inViewOptions = { threshold: 1 },
+  inViewOptions = { threshold: 1, initialInView: true, fallbackInView: true },
   callback
 }) => {
   const [lastDirection] = useState({ direction });

--- a/lib/hooks/keepInView.js
+++ b/lib/hooks/keepInView.js
@@ -17,7 +17,6 @@ export const directions = {
 };
 
 export const oppositeDirection = (direction) => {
-  console.log("??????????????????", direction);
   if (!direction || !directions[direction]) return "left";
   return directions[direction];
 };

--- a/lib/hooks/keepInView.js
+++ b/lib/hooks/keepInView.js
@@ -43,7 +43,7 @@ export const oppositeDirection = (direction) => {
 export const useKeepInView = ({
   direction,
   shown = false,
-  inViewOptions = {},
+  inViewOptions = { threshold: 1 },
   callback
 }) => {
   const [isShown, setIsShown] = useState(shown);

--- a/lib/hooks/keepInView.js
+++ b/lib/hooks/keepInView.js
@@ -50,7 +50,7 @@ export const useKeepInView = ({
   const { ref, inView } = useInView(inViewOptions);
   useEffect(() => {
     if (!inView && isShown) callback(oppositeDirection(direction));
-  }, [inView, direction, isShown]);
+  }, [inView, direction, isShown, callback]);
 
   return [ref, setIsShown];
 };

--- a/lib/hooks/keepInView.js
+++ b/lib/hooks/keepInView.js
@@ -54,7 +54,7 @@ export const useKeepInView = ({
       callback(newDirection);
       lastDirection.direction = newDirection;
     }
-  }, [inView, direction, isShown, callback]);
+  }, [inView, direction, isShown, callback, lastDirection]);
 
   return [ref, setIsShown];
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-cool-onclickoutside": "^1.5.9",
         "react-dates": "^21.8.0",
         "react-docgen": "^5.3.0",
+        "react-intersection-observer": "^9.4.3",
         "react-number-format": "^4.4.1",
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
@@ -329,6 +330,7 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.10.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.10.4"
@@ -2427,6 +2429,7 @@
     },
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
@@ -13579,6 +13582,7 @@
     },
     "node_modules/babel-plugin-styled-components": {
       "version": "1.11.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -13592,6 +13596,7 @@
     },
     "node_modules/babel-plugin-syntax-jsx": {
       "version": "6.18.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
@@ -14751,6 +14756,7 @@
     },
     "node_modules/camelize": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/caniuse-lite": {
@@ -15731,6 +15737,7 @@
     },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4"
@@ -15951,6 +15958,7 @@
     },
     "node_modules/css-to-react-native": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelize": "^1.0.0",
@@ -29499,6 +29507,7 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/postcss/node_modules/picocolors": {
@@ -30116,6 +30125,7 @@
     },
     "node_modules/react": {
       "version": "17.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -30381,6 +30391,7 @@
     },
     "node_modules/react-dom": {
       "version": "17.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -30393,6 +30404,7 @@
     },
     "node_modules/react-dom/node_modules/scheduler": {
       "version": "0.20.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -30453,6 +30465,14 @@
       },
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.3.tgz",
+      "integrity": "sha512-WNRqMQvKpupr6MzecAQI0Pj0+JQong307knLP4g/nBex7kYfIaZsPpXaIhKHR+oV8z+goUbH9e10j6lGRnTzlQ==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {
@@ -32365,6 +32385,7 @@
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/shebang-command": {
@@ -33330,6 +33351,7 @@
     },
     "node_modules/styled-components": {
       "version": "5.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -37183,6 +37205,7 @@
     },
     "@babel/helper-annotate-as-pure": {
       "version": "7.10.4",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.4"
       }
@@ -38630,7 +38653,8 @@
       }
     },
     "@emotion/stylis": {
-      "version": "0.8.5"
+      "version": "0.8.5",
+      "dev": true
     },
     "@emotion/unitless": {
       "version": "0.7.5"
@@ -38673,13 +38697,11 @@
     },
     "@firebase/auth-interop-types": {
       "version": "0.1.6",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@firebase/auth-types": {
       "version": "0.10.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@firebase/functions-types": {
       "version": "0.4.0",
@@ -38687,8 +38709,7 @@
     },
     "@firebase/installations-types": {
       "version": "0.3.4",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@firebase/logger": {
       "version": "0.2.6",
@@ -38696,8 +38717,7 @@
     },
     "@firebase/messaging-types": {
       "version": "0.5.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@firebase/performance-types": {
       "version": "0.0.13",
@@ -40213,8 +40233,7 @@
     },
     "@mdx-js/react": {
       "version": "1.6.22",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -42972,8 +42991,7 @@
         },
         "ws": {
           "version": "8.7.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -43612,8 +43630,7 @@
         },
         "react-docgen-typescript": {
           "version": "2.2.2",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -45125,13 +45142,11 @@
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -45205,8 +45220,7 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -45233,8 +45247,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -45714,8 +45727,7 @@
     },
     "babel-core": {
       "version": "7.0.0-bridge.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "babel-eslint": {
       "version": "8.2.6",
@@ -46091,6 +46103,7 @@
     },
     "babel-plugin-styled-components": {
       "version": "1.11.1",
+      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -46099,7 +46112,8 @@
       }
     },
     "babel-plugin-syntax-jsx": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "dev": true
     },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
@@ -46460,8 +46474,7 @@
     },
     "bluebird-retry": {
       "version": "0.11.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "bn.js": {
       "version": "5.1.2",
@@ -46936,7 +46949,8 @@
       }
     },
     "camelize": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "caniuse-lite": {
       "version": "1.0.30001346",
@@ -47627,7 +47641,8 @@
       }
     },
     "css-color-keywords": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "css-in-js-utils": {
       "version": "2.0.1",
@@ -47659,8 +47674,7 @@
         },
         "icss-utils": {
           "version": "5.1.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "postcss": {
           "version": "8.3.0",
@@ -47673,8 +47687,7 @@
         },
         "postcss-modules-extract-imports": {
           "version": "3.0.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "postcss-modules-local-by-default": {
           "version": "4.0.0",
@@ -47766,6 +47779,7 @@
     },
     "css-to-react-native": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -48933,8 +48947,7 @@
     },
     "eslint-config-prettier": {
       "version": "7.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-react-app": {
       "version": "6.0.0",
@@ -49281,8 +49294,7 @@
     },
     "eslint-plugin-react-hooks": {
       "version": "4.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "4.0.3",
@@ -50102,8 +50114,7 @@
         },
         "@firebase/firestore-types": {
           "version": "2.4.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "@firebase/functions": {
           "version": "0.6.16",
@@ -50176,8 +50187,7 @@
         },
         "@firebase/storage-types": {
           "version": "0.5.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "@firebase/util": {
           "version": "1.3.0",
@@ -52575,8 +52585,7 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -53708,8 +53717,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
       "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "marked": {
       "version": "0.7.0",
@@ -54833,8 +54841,7 @@
     },
     "parse-prop-types": {
       "version": "0.3.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "parse-repo": {
       "version": "1.0.4",
@@ -56279,8 +56286,7 @@
         },
         "react-docgen-typescript": {
           "version": "2.1.1",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "renderkid": {
           "version": "3.0.0",
@@ -56306,8 +56312,7 @@
         },
         "style-loader": {
           "version": "3.3.1",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "supports-color": {
           "version": "8.1.1",
@@ -56649,7 +56654,8 @@
       }
     },
     "postcss-value-parser": {
-      "version": "4.1.0"
+      "version": "4.1.0",
+      "dev": true
     },
     "preact-render-to-string": {
       "version": "5.1.20",
@@ -57062,6 +57068,7 @@
     },
     "react": {
       "version": "17.0.1",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -57080,21 +57087,17 @@
     },
     "react-codemirror2": {
       "version": "7.2.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-colorful": {
       "version": "5.1.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-cool-onclickoutside": {
-      "version": "1.5.9",
-      "requires": {}
+      "version": "1.5.9"
     },
     "react-create-component-from-tag-prop": {
-      "version": "1.4.0",
-      "requires": {}
+      "version": "1.4.0"
     },
     "react-dates": {
       "version": "21.8.0",
@@ -57135,8 +57138,7 @@
     },
     "react-docgen-typescript": {
       "version": "1.20.5",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-docgen-typescript-plugin": {
       "version": "1.0.1",
@@ -57196,8 +57198,7 @@
         },
         "react-docgen-typescript": {
           "version": "1.22.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -57230,6 +57231,7 @@
     },
     "react-dom": {
       "version": "17.0.1",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -57238,6 +57240,7 @@
       "dependencies": {
         "scheduler": {
           "version": "0.20.1",
+          "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
@@ -57284,6 +57287,11 @@
         "is-dom": "^1.0.0",
         "prop-types": "^15.0.0"
       }
+    },
+    "react-intersection-observer": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.3.tgz",
+      "integrity": "sha512-WNRqMQvKpupr6MzecAQI0Pj0+JQong307knLP4g/nBex7kYfIaZsPpXaIhKHR+oV8z+goUbH9e10j6lGRnTzlQ=="
     },
     "react-is": {
       "version": "16.13.1"
@@ -57481,8 +57489,7 @@
     },
     "react-universal-interface": {
       "version": "0.6.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-use": {
       "version": "17.3.1",
@@ -58599,7 +58606,8 @@
       }
     },
     "shallowequal": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -59282,6 +59290,7 @@
     },
     "styled-components": {
       "version": "5.2.1",
+      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -59296,8 +59305,7 @@
       }
     },
     "styled-components-breakpoint": {
-      "version": "2.1.1",
-      "requires": {}
+      "version": "2.1.1"
     },
     "styled-components-grid": {
       "version": "2.2.2",
@@ -59307,8 +59315,7 @@
       }
     },
     "styled-is": {
-      "version": "1.3.0",
-      "requires": {}
+      "version": "1.3.0"
     },
     "styled-system": {
       "version": "5.1.5",
@@ -60372,20 +60379,17 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
       "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-debounce": {
       "version": "3.4.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
       "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-latest": {
       "version": "1.2.1",
@@ -61187,15 +61191,13 @@
         },
         "ws": {
           "version": "8.5.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
     "webpack-filter-warnings-plugin": {
       "version": "1.2.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "webpack-hot-middleware": {
       "version": "2.25.1",
@@ -61263,8 +61265,7 @@
     },
     "webpack-require-from": {
       "version": "1.8.5",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "webpack-sources": {
       "version": "1.4.3",
@@ -61603,8 +61604,7 @@
     },
     "ws": {
       "version": "7.5.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "x-default-browser": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-cool-onclickoutside": "^1.5.9",
     "react-dates": "^21.8.0",
     "react-docgen": "^5.3.0",
+    "react-intersection-observer": "^9.4.3",
     "react-number-format": "^4.4.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",


### PR DESCRIPTION
## What this PR does, and why

Adds a custom hook to ensure components with `direction` props are in the view port.

At this stage it simply sets the direction to the exact opposite, e.g. `left` becomes `right`, `top` becomes `bottom` and diagonals like `topLeft` become `bottomRight`.

The hook is used in the `Popover` and `ActionsMenu` for this PR.
