### PR TITLE
ignoresd left and right bounds for scroll positioning

### DIFF
--- a/lib/hooks/keepInView.js
+++ b/lib/hooks/keepInView.js
@@ -25,11 +25,9 @@ const isWithinRootBounds = (intersectionObserverEntry) => {
   const rootBounds = intersectionObserverEntry.rootBounds;
   const intersectionRect = intersectionObserverEntry.intersectionRect;
   const topDiff = intersectionRect.top - rootBounds.top;
-  const leftDiff = intersectionRect.left - rootBounds.left;
   const bottomDiff = intersectionRect.bottom - rootBounds.bottom;
-  const rightDiff = intersectionRect.right - rootBounds.right;
 
-  return topDiff > 0 && leftDiff > 0 && bottomDiff < -100 && rightDiff < -100;
+  return topDiff > 0 && bottomDiff < -100;
 };
 
 /**


### PR DESCRIPTION
## What this PR does, and why

> Ensure the keep-in-view hook works for menus that are opened near the left and right edge of the browser window by disabling lateral scroll checks .
