### PR TITLE
Informative SVG graphic has no alternative text [3.1, 3.2]

### DIFF
--- a/lib/components/Icon/Icon.stories.js
+++ b/lib/components/Icon/Icon.stories.js
@@ -27,50 +27,54 @@ export default {
 
 export const defaultIcon = () => (
   <>
-    <Icon icon={["fas", "angle-down"]} />
-    <Icon icon={["fas", "plus"]} />
-    <Icon icon={["far", "user"]} />
+    <Icon icon={["fas", "angle-down"]} title="Down" />
+    <Icon icon={["fas", "plus"]} title="Plus" />
+    <Icon icon={["far", "user"]} title="User" />
   </>
 );
 
 export const colouredIcon = () => (
   <>
-    <Icon icon={["fas", "angle-down"]} color="primaryDark" />
-    <Icon icon={["fas", "plus"]} color="successDark" />
-    <Icon icon={["far", "user"]} color="dangerDark" />
+    <Icon icon={["fas", "angle-down"]} color="primaryDark" title="Down" />
+    <Icon icon={["fas", "plus"]} color="successDark" title="Plus" />
+    <Icon icon={["far", "user"]} color="dangerDark" title="User" />
   </>
 );
 
 export const iconSize = () => (
   <>
-    <Icon icon={["fas", "plus"]} size="sm" />
-    <Icon icon={["fas", "plus"]} size="rg" />
-    <Icon icon={["fas", "plus"]} size="lg" />
-    <Icon icon={["fas", "plus"]} size="2x" />
+    <Icon icon={["fas", "plus"]} size="sm" title="Plus" />
+    <Icon icon={["fas", "plus"]} size="rg" title="Plus" />
+    <Icon icon={["fas", "plus"]} size="lg" title="Plus" />
+    <Icon icon={["fas", "plus"]} size="2x" title="Plus" />
   </>
 );
 
 export const invertedIcons = () => (
   <Box bg="greyDarker" width="100%">
     <Flex alignItems="center" justifyContent="space-around">
-      <Icon icon={["fas", "angle-down"]} inverse />
-      <Icon icon={["fas", "plus"]} inverse />
-      <Icon icon={["far", "user"]} inverse />
+      <Icon icon={["fas", "angle-down"]} inverse title="Down" />
+      <Icon icon={["fas", "plus"]} inverse title="Plus" />
+      <Icon icon={["far", "user"]} inverse title="User" />
     </Flex>
   </Box>
 );
 
 export const animatedIcons = () => (
   <>
-    <Icon icon={["fas", "angle-down"]} spin />
-    <Icon icon={["fas", "plus"]} pulse />
+    <Icon icon={["fas", "angle-down"]} spin title="Spinning arrow" />
+    <Icon icon={["fas", "plus"]} pulse title="Spinning plus" />
   </>
 );
 
 export const transformsAndRotations = () => (
   <>
-    <Icon icon={["fas", "coffee"]} rotation="270" />
-    <Icon icon={["fas", "user"]} flip="vertical" />
-    <Icon icon={["fas", "certificate"]} transform="grow-8 up-10" />
+    <Icon icon={["fas", "coffee"]} rotation="270" title="Coffee" />
+    <Icon icon={["fas", "user"]} flip="vertical" title="User" />
+    <Icon
+      icon={["fas", "certificate"]}
+      transform="grow-8 up-10"
+      title="Certificate"
+    />
   </>
 );

--- a/lib/components/Icon/index.js
+++ b/lib/components/Icon/index.js
@@ -41,6 +41,7 @@ export default function Icon({
   transform,
   color,
   theme,
+  title,
   ...props
 }) {
   const component = (
@@ -60,6 +61,7 @@ export default function Icon({
         spin={spin}
         symbol={symbol}
         transform={transform}
+        title={title}
       />
     </IconWrapper>
   );
@@ -103,5 +105,7 @@ Icon.propTypes = {
   /** Power transforms to scale and position the icon */
   transform: PropTypes.any,
   /** Specifies the system design theme. */
-  theme: PropTypes.object
+  theme: PropTypes.object,
+  /** Set an accessabilty title for screen readers. */
+  title: PropTypes.string
 };

--- a/lib/components/Icon/index.js
+++ b/lib/components/Icon/index.js
@@ -61,7 +61,7 @@ export default function Icon({
         spin={spin}
         symbol={symbol}
         transform={transform}
-        title={`Icon-${title}`}
+        title={title && `Icon-${title}`}
       />
     </IconWrapper>
   );

--- a/lib/components/Icon/index.js
+++ b/lib/components/Icon/index.js
@@ -61,7 +61,7 @@ export default function Icon({
         spin={spin}
         symbol={symbol}
         transform={transform}
-        title={title}
+        title={`Icon-${title}`}
       />
     </IconWrapper>
   );


### PR DESCRIPTION
Add a `title` attribute to `Icon` which enables the default `Fontawesome` accessibility capabilites.

When `title` is set an `aria-labelledby` is added to the `<svg />` linked by id to a hidden `<title />` element.

Before:

```html
<svg 
  aria-hidden="true"
  focusable="false"
  data-prefix="fas"
  data-icon="angle-down"
  class="svg-inline--fa fa-angle-down fa-w-10"
  role="img"
  xmlns="http://www.w3.org/2000/svg"
  viewBox="0 0 320 512">
  <path fill="currentColor" d="..."></path>
</svg>
```

After:
```html
<svg 
  aria-labelledby="svg-inline--fa-title-tosHB4zVlbMz"
  data-prefix="fas"
  data-icon="angle-down"
  class="svg-inline--fa fa-angle-down fa-w-10"
  role="img"
  xmlns="http://www.w3.org/2000/svg"
  viewBox="0 0 320 512">
  <title id="svg-inline--fa-title-tosHB4zVlbMz">Down</title>
  <path fill="currentColor" d="..."></path>
</svg>
```

This relies on the developer setting the `title` when using an icon. A default could be added by converting the icon name to humanized word, ie `fa-check` would default to `Check`.

It may also be worth updating all applicable Icons in StoryBook to have a title.

Also the technique applied by FontAwesome differs from the accessibility docs but assume this method is appropriate.