### PR TITLE
Decorative image has no 'alt' attribute [2.1]

### DIFF
--- a/lib/components/Avatar/Avatar.mdx
+++ b/lib/components/Avatar/Avatar.mdx
@@ -15,6 +15,8 @@ Lastly you can specify whether it is being rendered on a dark background and the
 
 Also, if no title/subtitle is specified then it will only show the circle avatar part.
 
+When using an image and no title is set or the title is not a string then set the imageAlt attribute for accessiblity.
+
 Follow example code below to achieve desired option.
 
 ## Default avatar

--- a/lib/components/Avatar/Avatar.stories.js
+++ b/lib/components/Avatar/Avatar.stories.js
@@ -46,7 +46,10 @@ noImage.storyName = "No image";
 
 export const imageOnly = () => (
   <Spacer my={4}>
-    <Avatar image="https://uploads-ssl.webflow.com/5f4852427e784b4cada3e0d0/62f1f587bc47b25676f9ed1d_bw_avatar_adam.png" />
+    <Avatar
+      image="https://uploads-ssl.webflow.com/5f4852427e784b4cada3e0d0/62f1f587bc47b25676f9ed1d_bw_avatar_adam.png"
+      imageAlt="Ayden Lundgre"
+    />
   </Spacer>
 );
 imageOnly.storyName = "Image only";
@@ -64,6 +67,7 @@ export const nameLink = () => (
     subtitle="Senior Business Analyst"
     initials="AL"
     image="https://uploads-ssl.webflow.com/5f4852427e784b4cada3e0d0/62f1f587bc47b25676f9ed1d_bw_avatar_adam.png"
+    imageAlt="Ayden Lundgre"
   />
 );
 nameLink.storyName = "Name as link";
@@ -134,6 +138,7 @@ export const subtitleContent = () => (
       title={<StyledLink href="#">Ayden Lundgre</StyledLink>}
       initials="AL"
       image="https://uploads-ssl.webflow.com/5f4852427e784b4cada3e0d0/62f1f587bc47b25676f9ed1d_bw_avatar_adam.png"
+      imageAlt="Ayden Lundgre"
       subtitleContent={
         <Flex flexWrap="wrap">
           <Spacer mr="xs" mt="xs">
@@ -154,6 +159,7 @@ export const localTime = () => (
       title={<StyledLink href="#">Ayden Lundgre</StyledLink>}
       initials="AL"
       image="https://uploads-ssl.webflow.com/5f4852427e784b4cada3e0d0/62f1f587bc47b25676f9ed1d_bw_avatar_adam.png"
+      imageAlt="Ayden Lundgre"
       subtitleContent={<Badge mt="xs">Senior Business Analyst</Badge>}
       localTime="12:03pm local time"
     />
@@ -177,6 +183,7 @@ export const inverted = () => (
         subtitle="Senior Business Analyst"
         initials="AL"
         image="https://uploads-ssl.webflow.com/5f4852427e784b4cada3e0d0/62f1f587bc47b25676f9ed1d_bw_avatar_adam.png"
+        imageAlt="Ayden Lundgre"
       />
       <Avatar
         type="inverted"
@@ -192,6 +199,7 @@ export const inverted = () => (
         subtitle="Senior Business Analyst"
         initials="AL"
         image="https://uploads-ssl.webflow.com/5f4852427e784b4cada3e0d0/62f1f587bc47b25676f9ed1d_bw_avatar_adam.png"
+        imageAlt="Ayden Lundgre"
       />
     </Spacer>
   </Box>
@@ -205,6 +213,7 @@ export const alternateShapes = () => (
       title={<StyledLink href="#">Innovation Lab</StyledLink>}
       subtitle="15 team members"
       image="https://images.unsplash.com/photo-1582213782179-e0d53f98f2ca?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2370&q=80"
+      imageAlt="Team Photo"
       sizing="large"
     />
     <Avatar
@@ -212,6 +221,7 @@ export const alternateShapes = () => (
       title={<StyledLink href="#">Innovation Lab</StyledLink>}
       subtitle="15 team members"
       image="https://images.unsplash.com/photo-1582213782179-e0d53f98f2ca?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2370&q=80"
+      imageAlt="Team Photo"
     />
     <Avatar
       shape="square"
@@ -231,6 +241,7 @@ export const alternateShapes = () => (
       title={<StyledLink href="#">Innovation Lab</StyledLink>}
       subtitle="15 team members"
       image="https://images.unsplash.com/photo-1582213782179-e0d53f98f2ca?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2370&q=80"
+      imageAlt="Team Photo"
       sizing="large"
     />
     <Avatar
@@ -238,6 +249,7 @@ export const alternateShapes = () => (
       title={<StyledLink href="#">Innovation Lab</StyledLink>}
       subtitle="15 team members"
       image="https://images.unsplash.com/photo-1582213782179-e0d53f98f2ca?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2370&q=80"
+      imageAlt="Team Photo"
     />
     <Avatar
       shape="hexagon"
@@ -257,6 +269,7 @@ export const alternateShapes = () => (
       title={<StyledLink href="#">Javascript</StyledLink>}
       subtitle="Tagged 123 times"
       image="https://images.unsplash.com/photo-1627398242454-45a1465c2479?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2148&q=80"
+      imageAlt="Screen Photo"
       sizing="large"
     />
     <Avatar
@@ -264,6 +277,7 @@ export const alternateShapes = () => (
       title={<StyledLink href="#">Javascript</StyledLink>}
       subtitle="Tagged 123 times"
       image="https://images.unsplash.com/photo-1627398242454-45a1465c2479?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2148&q=80"
+      imageAlt="Screen Photo"
     />
     <Avatar
       shape="tag"

--- a/lib/components/Avatar/index.js
+++ b/lib/components/Avatar/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styled, { ThemeProvider } from "styled-components";
 import { space, layout, variant } from "styled-system";
 import PropTypes from "prop-types";
@@ -274,6 +274,7 @@ const LocalTime = styled(Popover)`
 const Avatar = ({
   sizing,
   image,
+  imageAlt,
   initials,
   title,
   subtitle,
@@ -290,10 +291,20 @@ const Avatar = ({
   const hasSubtitle = !!subtitle;
   const hasSubtitleContent = !!subtitleContent;
 
+  const alt = useMemo(() => {
+    if (!!imageAlt) {
+      return imageAlt;
+    }
+    
+    if (typeof(title) === "string") {
+      return title;
+    }
+  }, [imageAlt, title]);
+
   const component = (
     <AvatarWrapper {...props} type={type} sizing={sizing}>
       {image ? (
-        <Image src={image} sizing={sizing} shape={shape} />
+        <Image src={image} sizing={sizing} shape={shape} alt={alt} />
       ) : (
         <Shape
           shape={shape}
@@ -362,6 +373,8 @@ Avatar.propTypes = {
   type: PropTypes.oneOf(["inverted", "default"]),
   /** Specifies a source path for an image */
   image: PropTypes.string,
+  /** Specifies the alt text for an image */
+  imageAlt: PropTypes.string,
   /** Specifies initials of person if available */
   initials: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** Specifies custom content for avatar subtitle */

--- a/lib/components/Avatar/index.js
+++ b/lib/components/Avatar/index.js
@@ -292,11 +292,9 @@ const Avatar = ({
   const hasSubtitleContent = !!subtitleContent;
 
   const alt = useMemo(() => {
-    if (!!imageAlt) {
+    if (imageAlt) {
       return imageAlt;
-    }
-    
-    if (typeof(title) === "string") {
+    } else if (typeof title === "string") {
       return title;
     }
   }, [imageAlt, title]);


### PR DESCRIPTION
Adds an `alt` attribute to the avatar image. Will use `imageTag` or fallback to the `title` if its a string.
