### PR TITLE
Append currency symbol to label if defined [6.4]

### DIFF
--- a/lib/components/TextInput/index.js
+++ b/lib/components/TextInput/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import NumberFormat from "react-number-format";
 import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
@@ -286,7 +286,6 @@ const TextInput = React.forwardRef((props, ref) => {
     floating,
     id,
     bold,
-    label,
     invalid,
     valid,
     fullWidth,
@@ -306,6 +305,14 @@ const TextInput = React.forwardRef((props, ref) => {
       ref.current = node;
     };
   }
+
+  const label = useMemo(() => {
+    if (numberProps && numberProps.prefix) {
+      return `${props.label} ${numberProps.prefix}`;
+    }
+
+    return props.label;
+  }, [props.label, numberProps]);
 
   return (
     <Group fullWidth={fullWidth} {...InputStyles}>


### PR DESCRIPTION
If `numberProps.prefix` is defined then append it to the label for screen readers.

Before:
```html
<label for="numInput1" class="TextInput__Label-shde0o-3 keTmHt">Currency</label>
```

After:
```html
<label for="numInput1" class="TextInput__Label-shde0o-3 keTmHt">Currency $</label>
```
