### PR TITLE
Allow passing a titleLevel to support any heading tag [8.2]

### DIFF
--- a/lib/components/Avatar/Avatar.mdx
+++ b/lib/components/Avatar/Avatar.mdx
@@ -67,6 +67,14 @@ This component can support a link for the name.
   <Story id="components-avatar--large" />
 </Preview>
 
+## Title Level
+
+This component supports defining the heading level of the title. Options are H1, H2, H3 (default), H4, H5, H6.
+
+<Preview>
+  <Story id="components-avatar--title-level" />
+</Preview>
+
 ## Custom subtitle content
 
 <Preview>

--- a/lib/components/Avatar/Avatar.stories.js
+++ b/lib/components/Avatar/Avatar.stories.js
@@ -98,7 +98,8 @@ export const large = () => (
   <Spacer my={4}>
     <Avatar
       sizing="large"
-      title="Ayden Lundgre"
+      title="Ayden Lundgre TESTER"
+      titleLevel="H1"
       subtitle="Senior Business Analyst"
       initials="AL"
     />
@@ -119,6 +120,19 @@ export const large = () => (
   </Spacer>
 );
 large.storyName = "Large";
+
+export const titleLevel = () => (
+  <Spacer my={4}>
+    <Avatar
+      sizing="large"
+      title="Ayden Lundgre"
+      titleLevel="H1"
+      subtitle="Senior Business Analyst"
+      initials="AL"
+    />
+  </Spacer>
+);
+titleLevel.storyName = "Title Level";
 
 export const subtitleContent = () => (
   <Spacer my={4}>

--- a/lib/components/Avatar/index.js
+++ b/lib/components/Avatar/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import styled, { ThemeProvider } from "styled-components";
 import { space, layout, variant } from "styled-system";
 import PropTypes from "prop-types";
-import { H3, Text } from "../Typography";
+import Header, { Text } from "../Typography";
 import Icon from "../Icon";
 import Popover from "../Popover";
 import StatusDot from "../StatusDot";
@@ -178,7 +178,10 @@ const Shape = styled("div")(
     })
 );
 
-const Title = styled(H3)(
+const Title = styled(({ titleLevel, ...props }) => {
+  const Heading = Header[titleLevel];
+  return React.cloneElement(<Heading />, props);
+})(
   (props) =>
     css({
       fontSize: themeGet("fontSizes.2")(props),
@@ -276,6 +279,7 @@ const Avatar = ({
   image,
   initials,
   title,
+  titleLevel = "H3",
   subtitle,
   subtitleContent,
   type,
@@ -319,7 +323,12 @@ const Avatar = ({
       {(hasTitle || hasSubtitle) && (
         <TextContent type={type} sizing={sizing} theme={theme}>
           {hasTitle && (
-            <Title type={type} sizing={sizing} theme={theme}>
+            <Title
+              titleLevel={titleLevel}
+              type={type}
+              sizing={sizing}
+              theme={theme}
+            >
               {title}
             </Title>
           )}
@@ -372,6 +381,8 @@ Avatar.propTypes = {
   uppercase: PropTypes.bool,
   /** Specifies title / name as just plain text, or an element like a hyperlink or react router link */
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** Specifies the component to wrap the heading, defaults to H3 */
+  titleLevel: PropTypes.oneOf(["H1", "H2", "H3", "H4", "H5", "H6"]),
   /** Specifies subtitle / role */
   subtitle: PropTypes.string,
   /** Specifies local time */


### PR DESCRIPTION
This allows passing a `titleLevel` prop which maps to one of the Typography heading elements.

Before:
```html
<Avatar
  sizing="large"
  title="Ayden Lundgre"
  subtitle="Senior Business Analyst"
  initials="AL"
/>

<div class="Avatar__TextContent-sc-1wtet2j-1 ZpYup">
  <h3 class="Typography__H1-sc-1613j99-0 hnVnbm Avatar__Title-sc-1wtet2j-4 fwEKEl">Ayden Lundgre</h3>
  <span class="Typography__Text-sc-1613j99-8 Avatar__Subtitle-sc-1wtet2j-5 zJCfv juppZJ">Senior Business Analyst</span>
</div>
```

After:
```html
<Avatar
  sizing="large"
  title="Ayden Lundgre"
  titleLevel="H1"
  subtitle="Senior Business Analyst"
  initials="AL"
/>

<div class="Avatar__TextContent-sc-1wtet2j-1 ZpYup">
  <h1 class="Typography__H1-sc-1613j99-0 hnVnbm Avatar__Title-sc-1wtet2j-4 fwEKEl">Ayden Lundgre</h1>
  <span class="Typography__Text-sc-1613j99-8 Avatar__Subtitle-sc-1wtet2j-5 zJCfv juppZJ">Senior Business Analyst</span>
</div>
```

This was the only appropriate way I could find for easily using the existing `Typography` components and keeping all the exisiting behaviour. I went with `titleLevel` as that the language used in the accessibility docs.