### PR TITLE
Add aria tags to the sidebar [9.1]

### DIFF
--- a/lib/components/Sidebar/Sidebar.stories.js
+++ b/lib/components/Sidebar/Sidebar.stories.js
@@ -29,13 +29,13 @@ export default {
 export const defaultSidebar = () => (
   <Sidebar>
     <SidebarTabs>
-      <SidebarTab active badge="3">
+      <SidebarTab active badge="3" ariaLabel="Messages">
         <Icon icon={["fas", "filter"]} size="lg" />
       </SidebarTab>
-      <SidebarTab>
+      <SidebarTab ariaLabel="Preferences">
         <Icon icon={["fas", "cog"]} size="lg" />
       </SidebarTab>
-      <SidebarTab bottomAligned>
+      <SidebarTab bottomAligned ariaLabel="Info">
         <Icon icon={["fas", "info-circle"]} size="lg" />
       </SidebarTab>
     </SidebarTabs>

--- a/lib/components/Sidebar/index.js
+++ b/lib/components/Sidebar/index.js
@@ -64,9 +64,11 @@ SidebarTabs.propTypes = {
   SidebarStyles: PropTypes.object
 };
 
-export const SidebarTab = styled("label").attrs((props) => ({
+export const SidebarTab = styled("button").attrs((props) => ({
   className: props.badge ? "Sidebar__Badge" : "",
-  marginTop: props.bottomAligned ? "auto" : "0"
+  marginTop: props.bottomAligned ? "auto" : "0",
+  "aria-label": props.ariaLabel,
+  "aria-expanded": props.active ? "true" : "false"
 }))(
   (props) =>
     css({
@@ -81,6 +83,9 @@ export const SidebarTab = styled("label").attrs((props) => ({
       color: themeGet("colors.greyLightest")(props),
       bg: props.active ? themeGet("colors.greyDarker")(props) : "transparent",
       cursor: props.active ? "default" : "pointer",
+      border: "none",
+      padding: 0,
+      fontSize: "1em",
       path: {
         transition: themeGet("transition.transitionDefault")(props),
         fill: themeGet("colors.greyLightest")(props)
@@ -125,7 +130,9 @@ SidebarTab.propTypes = {
   /** Sets last sidebar tab position to bottom of sidebar */
   bottomAligned: PropTypes.bool,
   /** Set the styles for this subcomponent if needed, using the `space` and `layout` styled-system categories */
-  SidebarStyles: PropTypes.object
+  SidebarStyles: PropTypes.object,
+  /** Set the ariaLabel */
+  ariaLabel: PropTypes.string
 };
 
 export const SidebarPanels = styled("div")(


### PR DESCRIPTION
Replace sidebar label with a button using `aria-label` and `aria-expanded` attributes.

Before:
```html
<label class="Sidebar__SidebarTab-wr9mfw-2 bDqZrz Sidebar__Badge">
  ...
</label>
```
After:
```html
<button class="Sidebar__SidebarTab-wr9mfw-2 ljExJn Sidebar__Badge" aria-label="Messages" aria-expanded="true">
  ...
</button>
```