### PR TITLE
Scripted header button not keyboard focusable [17.5]

### DIFF
--- a/lib/components/Header/index.js
+++ b/lib/components/Header/index.js
@@ -271,7 +271,7 @@ const SearchContainer = styled("div")(
   layout
 );
 
-const MobileMenuToggle = styled("label")((props) =>
+const MobileMenuToggle = styled("button")((props) =>
   css({
     zIndex: 4,
     cursor: "pointer",
@@ -279,7 +279,7 @@ const MobileMenuToggle = styled("label")((props) =>
     background: "none",
     border: "none",
     position: "relative",
-    paddingBottom: "7px",
+    padding: "0 0 7px",
     display: "block",
     "&:hover, &:focus": {
       outline: "0",
@@ -394,8 +394,11 @@ const MobileNavToggle = styled("input")((props) =>
   })
 );
 
-const MobileNavMenu = styled("div")((props) =>
+const MobileNavMenu = styled("div").attrs((props) => ({
+  "aria-hidden": `${!props.isOpen}`
+}))((props) =>
   css({
+    display: props.isOpen ? "block" : "none",
     position: "fixed",
     overflowY: "auto",
     height: "100vh",
@@ -483,8 +486,13 @@ export default function Header({
   lightAppSwitcher
 }) {
   const [toggleState, setToggle] = useState(false);
+  const [mobileMenuIsOpen, setMobileMenuIsOpen] = useState(false);
   const switcherRef = useRef();
   const menuRef = useRef();
+
+  const toggleMobileMenu = () => {
+    setMobileMenuIsOpen((state) => !state);
+  };
 
   const closeMenu = () => {
     setToggle(false);
@@ -525,7 +533,12 @@ export default function Header({
 
   const component = (
     <>
-      <MobileNavToggle type="checkbox" id={navToggleId} />
+      <MobileNavToggle
+        type="checkbox"
+        checked={mobileMenuIsOpen}
+        defaultChecked={mobileMenuIsOpen}
+        id={navToggleId}
+      />
       <Bar theme={theme} dataTestId={dataTestId} variant={variant}>
         <Flex alignItems="center">
           {appSwitcher && (
@@ -626,12 +639,17 @@ export default function Header({
               theme={theme}
             />
           </FlexItem>
-          <MobileMenuToggle htmlFor={navToggleId} theme={theme}>
+          <MobileMenuToggle
+            theme={theme}
+            onClick={toggleMobileMenu}
+            aria-expanded={`${mobileMenuIsOpen}`}
+            aria-label="Menu"
+          >
             <Hamburger id="hamburger-menu-icon" />
           </MobileMenuToggle>
         </Flex>
       </Bar>
-      <MobileNavMenu aria-hidden="true">
+      <MobileNavMenu isOpen={mobileMenuIsOpen}>
         <Box m="s">
           <Box
             borderBottomWidth={1}


### PR DESCRIPTION
### Label / Button

Add relevant `aria-expanded` & `aria-label` attributes.

Before:
```html
<label for="defaultHeader" class="Header__MobileMenuToggle-yf04b-17 cdJYTh">
  <span id="hamburger-menu-icon" class="Header__Hamburger-yf04b-18 ivCBYA"></span>
</label>
```

After closed:
```html
<button aria-expanded="false" aria-label="Menu" class="Header__MobileMenuToggle-yf04b-17 dGwaQb">
  <span id="hamburger-menu-icon" class="Header__Hamburger-yf04b-18 ivCBYA"></span>
</button>
```

After open:
```html
<button aria-expanded="true" aria-label="Menu" class="Header__MobileMenuToggle-yf04b-17 dGwaQb">
  <span id="hamburger-menu-icon" class="Header__Hamburger-yf04b-18 ivCBYA"></span>
</button>
```

### Mobile Menu

Add relevant `aria-hidden` attribute and ensure element is hidden off screen.

Before:
```html
<div aria-hidden="true" class="Header__MobileNavMenu-yf04b-20 hzLaPb">
```

After closed:

```html
<div aria-hidden="true" class="Header__MobileNavMenu-yf04b-20 hzLaPb">
```

```css
.hzLaPb {
  display: none;
}
```

After open:

```html
<div aria-hidden="false" class="Header__MobileNavMenu-yf04b-20 hzLaPb">
```

```css
.hzLaPb {
  display: block;
}
```
