### PR TITLE
Add relevant aria labels to the actions menu [27.1 - 27.4]

### DIFF
--- a/lib/components/ActionsMenu/ActionsMenu.stories.js
+++ b/lib/components/ActionsMenu/ActionsMenu.stories.js
@@ -42,7 +42,7 @@ defaultActionsMenu.storyName = "Default";
 
 export const leftOffsetActionsMenu = () => (
   <Flex justifyContent="flex-end">
-    <ActionsMenu direction="left">
+    <ActionsMenu ariaLabel="Options Menu" direction="left">
       <ActionsMenuItem href="https://orchestrated.io/">
         Open details page
       </ActionsMenuItem>

--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -118,7 +118,7 @@ const Icon = styled.div`
 `;
 
 const Menu = styled.div`
-  display: block;
+  display: ${(props) => (props.isOpen ? "block" : "none")};
   position: absolute;
   left: ${(props) =>
     props.menuLeftPosition
@@ -178,7 +178,7 @@ export const ActionsMenuItem = styled((props) => {
   }
 
   return <Component {...newProps} />;
-})`
+}).attrs({ role: "listitem" })`
   white-space: nowrap;
   display: block;
   width: 100%;
@@ -229,6 +229,7 @@ export const ActionsMenuBody = ({
   menuWidth,
   customTriggerComponent,
   children,
+  ariaLabel,
   ...props
 }) => {
   const [menuPosition] = useState({
@@ -267,12 +268,19 @@ export const ActionsMenuBody = ({
 
   let triggerBtn = null;
   if (customTriggerComponent) {
+    console.log(ariaLabel);
     triggerBtn = React.cloneElement(customTriggerComponent, {
-      onClick: onToggleInView
+      onClick: onToggleInView,
+      "aria-label": ariaLabel,
+      "aria-expanded": `${toggleState}`
     });
   } else {
     triggerBtn = (
-      <Control onClick={onToggleInView}>
+      <Control
+        aria-label={ariaLabel}
+        aria-expanded={`${toggleState}`}
+        onClick={onToggleInView}
+      >
         <Icon isOpen={toggleState} />
       </Control>
     );
@@ -289,6 +297,7 @@ export const ActionsMenuBody = ({
         menuRightPosition={menuPosition.menuRightPosition}
         menuWidth={menuWidth}
         ref={ref}
+        role="list"
       >
         {children}
       </Menu>
@@ -315,7 +324,8 @@ ActionsMenuBody.propTypes = {
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)
   ]),
-  theme: PropTypes.object
+  theme: PropTypes.object,
+  ariaLabel: PropTypes.string
 };
 
 const ActionsMenu = React.forwardRef(
@@ -327,6 +337,7 @@ const ActionsMenu = React.forwardRef(
       isOpen = false,
       theme,
       closeOnClick = true,
+      ariaLabel = "Options Menu",
       ...props
     },
     ref
@@ -372,6 +383,7 @@ const ActionsMenu = React.forwardRef(
         customTriggerComponent={customTriggerComponent}
         direction={direction}
         theme={theme}
+        ariaLabel={ariaLabel}
         {...props}
       >
         {children}
@@ -390,7 +402,9 @@ ActionsMenu.propTypes = {
     PropTypes.arrayOf(PropTypes.node)
   ]),
   /** Specifies the colour theme */
-  theme: PropTypes.object
+  theme: PropTypes.object,
+  /** Specifies the aria-label for the button */
+  ariaLabel: PropTypes.object
 };
 
 export default ActionsMenu;


### PR DESCRIPTION
Before:
```html
<div class="ActionsMenu__Wrapper-yvbni2-0 iEyrlM">
  <button class="ActionsMenu__Control-yvbni2-1 iuQRhd">
    <div class="ActionsMenu__Icon-yvbni2-2 hQaqIj"></div>
  </button>
  <div direction="left" class="ActionsMenu__Menu-yvbni2-3 fBFEua">
    <a href="https://orchestrated.io/" class="ActionsMenu__ActionsMenuItem-yvbni2-5 ddewAQ">
      Open details page
    </a>
    <a class="ActionsMenu__ActionsMenuItem-yvbni2-5 ddewAQ" href="/">
      Edit
    </a>
    <button class="ActionsMenu__ActionsMenuItem-yvbni2-5 ddewAQ" type="button">
      Remove
    </button>
  </div>
</div>
```

After:
```html
<div class="ActionsMenu__Wrapper-yvbni2-0 iEyrlM">
  <button aria-label="Options Menu" aria-expanded="false" class="ActionsMenu__Control-yvbni2-1 iuQRhd">
    <div class="ActionsMenu__Icon-yvbni2-2 hQaqIj"></div>
  </button>
  <div direction="left" role="list" class="ActionsMenu__Menu-yvbni2-3 hnXimm">
    <a href="https://orchestrated.io/" role="listitem" class="ActionsMenu__ActionsMenuItem-yvbni2-5 ddewAQ">
      Open details page
    </a>
    <a role="listitem" class="ActionsMenu__ActionsMenuItem-yvbni2-5 ddewAQ" href="/">
      Edit
    </a>
    <button role="listitem" class="ActionsMenu__ActionsMenuItem-yvbni2-5 ddewAQ" type="button">
      Remove
    </button>
  </div>
</div>
```