### PR TITLE
[18.5] Auto-suggest not screen reader accessible

### DIFF
--- a/lib/components/Tag/index.js
+++ b/lib/components/Tag/index.js
@@ -238,6 +238,8 @@ export default function Tag({
   isPending,
   small,
   highlighted,
+  editButtonAreaLabel,
+  removeButtonAreaLabel,
   ...props
 }) {
   const component = (
@@ -268,6 +270,7 @@ export default function Tag({
       </TagValue>
       {showEdit && (
         <TagEdit
+          aria-label={editButtonAreaLabel}
           selected={selected}
           highlighted={highlighted}
           disabled={disabled}
@@ -279,6 +282,7 @@ export default function Tag({
       )}
       {showRemove && (
         <TagRemove
+          aria-label={removeButtonAreaLabel}
           selected={selected}
           highlighted={highlighted}
           disabled={disabled}
@@ -327,7 +331,11 @@ Tag.propTypes = {
   /** Applies the small variant styles */
   small: PropTypes.bool,
   /** Applies a highlighted style and colour to the tag */
-  highlighted: PropTypes.bool
+  highlighted: PropTypes.bool,
+  /** Applies area-label attribute to edit tag button */
+  editButtonAreaLabel: PropTypes.string,
+  /** Applies area-label attribute to remove tag button */
+  removeButtonAreaLabel: PropTypes.string
 };
 
 Tag.defaultProps = {
@@ -337,5 +345,7 @@ Tag.defaultProps = {
   disabled: false,
   showEdit: false,
   showRemove: false,
-  showStrikeThrough: false
+  showStrikeThrough: false,
+  editButtonAreaLabel: "Edit",
+  removeButtonAreaLabel: "Remove",
 };


### PR DESCRIPTION
That PR adds area-label to "Edit" and "Remove" tags buttons.
