### PR TITLE
Chore/add ability to focus inputs

### DIFF
--- a/lib/components/Select/index.js
+++ b/lib/components/Select/index.js
@@ -10,6 +10,8 @@ import shouldForwardProp from "@styled-system/should-forward-prop";
 import { themeGet } from "@styled-system/theme-get";
 import { Small } from "../Typography";
 
+import useInputFocus from "../../hooks/useInputFocus";
+
 const SelectStyles = compose(space, layout);
 
 const Wrapper = styled("div")
@@ -62,6 +64,7 @@ const Label = styled("label")
  */
 const Select = forwardRef((props, ref) => {
   const theme = useTheme();
+  const inputRef = useInputFocus(ref, props.focus);
   const { updateStyles = (s) => s } = props;
 
   const customStyles = updateStyles({
@@ -271,7 +274,7 @@ const Select = forwardRef((props, ref) => {
       )}
       {props.selectType === "creatable" ? (
         <CreatableSelect
-          ref={ref}
+          ref={inputRef}
           styles={customStyles}
           theme={theme}
           inputId={props.inputId}
@@ -283,7 +286,7 @@ const Select = forwardRef((props, ref) => {
         />
       ) : props.selectType === "async" ? (
         <AsyncSelect
-          ref={ref}
+          ref={inputRef}
           styles={customStyles}
           theme={theme}
           inputId={props.inputId}
@@ -295,7 +298,7 @@ const Select = forwardRef((props, ref) => {
         />
       ) : (
         <ReactSelect
-          ref={ref}
+          ref={inputRef}
           styles={customStyles}
           theme={theme}
           inputId={props.inputId}
@@ -352,7 +355,9 @@ Select.propTypes = {
   /** Applies invalid input styles */
   invalid: PropTypes.bool,
   /** Shows asterisk to denote a mandatory field */
-  mandatory: PropTypes.bool
+  mandatory: PropTypes.bool,
+  /** Focus on input */
+  focus: PropTypes.bool
 };
 
 Select.defaultProps = {

--- a/lib/components/TextInput/index.js
+++ b/lib/components/TextInput/index.js
@@ -10,6 +10,7 @@ import {
 } from "@styled-system/should-forward-prop";
 import Icon from "../Icon";
 import { themeGet } from "@styled-system/theme-get";
+import useInputFocus from "../../hooks/useInputFocus";
 
 const InputStyles = compose(space, layout);
 
@@ -293,16 +294,17 @@ const TextInput = React.forwardRef((props, ref) => {
     iconLeft,
     iconRight,
     InputStyles,
-    height
+    height,
+    focus
   } = props;
 
-  // Strip numberProps from props for Input
+  const inputRef = useInputFocus(ref, focus);
   const { numberProps, ...rest } = props;
 
   let getNumberInputRef = null;
-  if (numberProps && ref) {
+  if (numberProps && inputRef) {
     getNumberInputRef = (node) => {
-      ref.current = node;
+      inputRef.current = node;
     };
   }
 
@@ -340,7 +342,7 @@ const TextInput = React.forwardRef((props, ref) => {
         <Input
           data-testid={props["data-testid"]}
           height={height}
-          ref={ref}
+          ref={inputRef}
           {...rest}
         />
       )}
@@ -410,7 +412,9 @@ TextInput.propTypes = {
   /** Specifies the `data-testid` attribute for testing. */
   "data-testid": PropTypes.string,
   /** Specifies any additional `space` and `layout` props for the entire component */
-  InputStyles: PropTypes.object
+  InputStyles: PropTypes.object,
+  /** Focus on input */
+  focus: PropTypes.bool
 };
 
 export default TextInput;

--- a/lib/hooks/useInputFocus.js
+++ b/lib/hooks/useInputFocus.js
@@ -1,0 +1,14 @@
+import React, { useEffect } from "react";
+
+const useInputFocus = (ref = null, focus) => {
+  const inputRef = ref || React.createRef();
+  useEffect(() => {
+    if (focus && inputRef && inputRef.current && inputRef.current.focus) {
+      inputRef.current.focus();
+    }
+  }, [inputRef, focus]);
+
+  return inputRef;
+};
+
+export default useInputFocus;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "orcs-design-system",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orcs-design-system",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "engines": {
     "node": "18.17.1"
   },


### PR DESCRIPTION
## Changes
* Allow to pass `focus` prop to make text input and select components focus