### PR TITLE
Allow Toggle to work with keyboard events [ORC-95]

### DIFF
--- a/lib/components/Toggle/index.js
+++ b/lib/components/Toggle/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import PropTypes from "prop-types";
 import styled, { css, ThemeProvider } from "styled-components";
 import { space, layout } from "styled-system";
@@ -135,18 +135,35 @@ export default function Toggle({
   small,
   theme,
   label,
-  checked,
   disabled,
   srHide,
   ...props
 }) {
+  const [isChecked, setIsChecked] = useState(props.checked || false);
+  const [isFocused, setIsFocused] = useState(false);
+
+  const toggleIsChecked = () => setIsChecked((state) => !state);
+
+  const handleOnKeyUp = useCallback(
+    ({ key }) => {
+      if (isFocused && key == "Enter") {
+        toggleIsChecked();
+      }
+    },
+    [isFocused]
+  );
+
   const component = (
     <Group inverted={inverted}>
       <Input
         id={id}
-        checked={checked}
+        checked={isChecked}
         disabled={disabled}
         srHide={srHide}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        onChange={toggleIsChecked}
+        onKeyUp={handleOnKeyUp}
         {...props}
       />
       <Item htmlFor={id} small={small} disabled={disabled} />

--- a/lib/components/Toggle/index.js
+++ b/lib/components/Toggle/index.js
@@ -143,6 +143,7 @@ export default function Toggle({
   const [isFocused, setIsFocused] = useState(false);
 
   const toggleIsChecked = () => setIsChecked((state) => !state);
+  const toggleIsFocused = () => setIsFocused((state) => !state);
 
   const handleOnKeyUp = useCallback(
     ({ key }) => {
@@ -160,8 +161,8 @@ export default function Toggle({
         checked={isChecked}
         disabled={disabled}
         srHide={srHide}
-        onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
+        onFocus={toggleIsFocused}
+        onBlur={toggleIsFocused}
         onChange={toggleIsChecked}
         onKeyUp={handleOnKeyUp}
         {...props}


### PR DESCRIPTION
Enables the Toggle component to checked/unchecked via the keyboard.

Also while working on this I notice thats it difficult to tell when the Toggle is focused. Perhaps the border should be updated to `shadows.thickOutline`?