### PR TITLE
HELP-7078 Modal closing on select X click

### DIFF
--- a/lib/components/Modal/index.js
+++ b/lib/components/Modal/index.js
@@ -224,7 +224,7 @@ const Modal = ({
         window.removeEventListener(type, handler, true);
       });
     };
-  }, [visible]);
+  }, [visible, onClose, overlayID]);
 
   const component = (
     <Overlay

--- a/lib/components/Modal/index.js
+++ b/lib/components/Modal/index.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import ReactDOM from "react-dom";
-import useOnclickOutside from "react-cool-onclickoutside";
 import PropTypes from "prop-types";
 import styled, { keyframes, ThemeProvider } from "styled-components";
 import FocusTrap from "focus-trap-react";
@@ -164,14 +163,6 @@ const Modal = ({
 }) => {
   const [lastActiveElement, setLastActiveElement] = useState(null);
 
-  const options = {
-    disabled: !visible
-  };
-
-  const modalRef = useOnclickOutside(() => {
-    onClose();
-  }, options);
-
   const ariaLabel = useMemo(() => {
     if (restProps.ariaLabel) {
       return restProps.ariaLabel;
@@ -210,6 +201,31 @@ const Modal = ({
     }
   }, [visible, focusLastActiveElement, lastActiveElement]);
 
+  useEffect(() => {
+    if (!visible) return;
+
+    /* Adding onClick handler on the Overlay does not work.
+     * So we add a global listener and check if the element clicked is the
+     * overlay vida overlayID.
+     */
+    const handler = (e) => {
+      if (e.target.id === overlayID) {
+        onClose();
+      }
+    };
+    const eventTypes = ["touchstart", "click"];
+
+    eventTypes.map((type) => {
+      window.addEventListener(type, handler, true);
+    });
+
+    return () => {
+      eventTypes.map((type) => {
+        window.removeEventListener(type, handler, true);
+      });
+    };
+  }, [visible]);
+
   const component = (
     <Overlay
       alignItems="center"
@@ -219,46 +235,25 @@ const Modal = ({
     >
       {visible && (
         <FocusTrap focusTrapOptions={{ onDeactivate: onClose }}>
-          <div>
-            <div
-              ref={modalRef}
-              role="dialog"
-              aria-modal="true"
-              aria-label={ariaLabel}
+          <div role="dialog" aria-modal="true" aria-label={ariaLabel}>
+            <Container
+              width={width}
+              height={height}
+              maxWidth={maxWidth}
+              maxHeight={maxHeight}
+              minWidth={minWidth}
+              minHeight={minHeight}
+              overflow={overflow}
+              borderRadius="2"
+              bg="white"
+              p="r"
+              id={modalID}
             >
-              <Container
-                width={width}
-                height={height}
-                maxWidth={maxWidth}
-                maxHeight={maxHeight}
-                minWidth={minWidth}
-                minHeight={minHeight}
-                overflow={overflow}
-                borderRadius="2"
-                bg="white"
-                p="r"
-                id={modalID}
-              >
-                {headerContent ? (
-                  <HeaderContent>
-                    <Box mr="xl" width="100%">
-                      {headerContent}
-                    </Box>
-                    <CloseButton
-                      onClick={onClose}
-                      className="modal-close"
-                      small
-                      px="6px"
-                      aria-label="Close dialog"
-                    >
-                      <Icon
-                        icon={["fas", "times"]}
-                        color="greyDark"
-                        size="lg"
-                      />
-                    </CloseButton>
-                  </HeaderContent>
-                ) : (
+              {headerContent ? (
+                <HeaderContent>
+                  <Box mr="xl" width="100%">
+                    {headerContent}
+                  </Box>
                   <CloseButton
                     onClick={onClose}
                     className="modal-close"
@@ -268,18 +263,26 @@ const Modal = ({
                   >
                     <Icon icon={["fas", "times"]} color="greyDark" size="lg" />
                   </CloseButton>
-                )}
-                <ScrollableContent
-                  headerContent={headerContent}
-                  overflow={overflow}
+                </HeaderContent>
+              ) : (
+                <CloseButton
+                  onClick={onClose}
+                  className="modal-close"
+                  small
+                  px="6px"
+                  aria-label="Close dialog"
                 >
-                  {children}
-                </ScrollableContent>
-                {footerContent && (
-                  <FooterContent>{footerContent}</FooterContent>
-                )}
-              </Container>
-            </div>
+                  <Icon icon={["fas", "times"]} color="greyDark" size="lg" />
+                </CloseButton>
+              )}
+              <ScrollableContent
+                headerContent={headerContent}
+                overflow={overflow}
+              >
+                {children}
+              </ScrollableContent>
+              {footerContent && <FooterContent>{footerContent}</FooterContent>}
+            </Container>
           </div>
         </FocusTrap>
       )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orcs-design-system",
-  "version": "3.1.32",
+  "version": "3.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orcs-design-system",
-      "version": "3.1.32",
+      "version": "3.1.33",
       "dependencies": {
         "@styled-system/css": "^5.1.5",
         "@styled-system/prop-types": "^5.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orcs-design-system",
-  "version": "3.1.32",
+  "version": "3.1.33",
   "engines": {
     "node": "18.17.1"
   },


### PR DESCRIPTION

## What this PR does, and why

> There was a race condition for `useOnClickOutside` where by the time the event handler was called, the selected option was removed from the DOM. This caused the `useOnClickOutside` handler to think that the clicked element was outside the element because the element was not a child of `modalRef` any more.
