### PR TITLE
HELP-8042 slowness due to floating UI

### DIFF
--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -350,20 +350,14 @@ export const ActionsMenuBody = ({
     [closeOnClick, closeMenu, id, actionMenu]
   );
 
-  const visible = useMemo(
-    () => actionMenu.context.open,
-    [actionMenu.context.open]
-  );
-
-  const sharedContentProps = useMemo(
+  const style = useMemo(
     () => ({
-      "aria-labelledby": actionMenu.labelId,
-      "data-testid": `${dataTestId}__menu`
+      ...actionMenu.floatingStyles,
+      zIndex: getFloatingUiZIndex(actionMenu.refs.reference)
     }),
-    [actionMenu.labelId, dataTestId]
+    [actionMenu.floatingStyles, actionMenu.refs.reference]
   );
 
-  console.log("visible", visible, props);
   const component = (
     <ActionMenuContext.Provider value={value}>
       <Wrapper {...props}>
@@ -375,12 +369,10 @@ export const ActionsMenuBody = ({
           >
             <FloatingFocusManager context={actionMenu.context} modal={true}>
               <StyledActionsMenuContainer
-                {...sharedContentProps}
+                aria-labelledby={actionMenu.labelId}
+                data-testid={`${dataTestId}__menu`}
                 {...actionMenu.getFloatingProps(props)}
-                style={{
-                  ...actionMenu.floatingStyles,
-                  zIndex: getFloatingUiZIndex(actionMenu.refs.reference)
-                }}
+                style={style}
                 className="actionMenu-content visible"
                 aria-hidden="false"
                 ref={ref}
@@ -399,7 +391,8 @@ export const ActionsMenuBody = ({
           update all the tests in teamform-app-ui to open the ActionsMenu *
           before assertion. **/
           <StyledActionsMenuContainer
-            {...sharedContentProps}
+            aria-labelledby={actionMenu.labelId}
+            data-testid={`${dataTestId}__menu`}
             className="actionMenu-content hack-for-legacy-tests"
           >
             <Menu menuWidth={menuWidth} isOpen={toggleState}>

--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -68,6 +68,16 @@ const StyledActionsMenuContainer = styled.div`
   opacity: 0;
   visibility: hidden;
 
+  &.hack-for-legacy-tests {
+    position: absolute;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    height: 0;
+    width: 0;
+    padding: 0;
+  }
+
   &.visible {
     visibility: visible;
     opacity: 1;
@@ -330,24 +340,12 @@ export const ActionsMenuBody = ({
 
   const visible = actionMenu.context.open;
 
-  const ActionMenuContent = (
-    <StyledActionsMenuContainer
-      ref={ref}
-      style={{
-        ...actionMenu.floatingStyles,
-        zIndex: getFloatingUiZIndex(actionMenu.refs.reference)
-      }}
-      aria-labelledby={actionMenu.labelId}
-      {...actionMenu.getFloatingProps(props)}
-      className={`actionMenu-content ${visible ? "visible" : ""}`}
-      aria-hidden={visible ? "false" : "true"}
-      data-testid={`${dataTestId}__menu`}
-    >
-      <Menu menuWidth={menuWidth} isOpen={toggleState}>
-        {children}
-      </Menu>
-    </StyledActionsMenuContainer>
-  );
+  const sharedContentProps = {
+    "aria-labelledby": actionMenu.labelId,
+    className: `actionMenu-content ${visible ? "visible" : ""}`,
+    "aria-hidden": visible ? "false" : "true",
+    "data-testid": `${dataTestId}__menu`
+  };
 
   const component = (
     <ActionMenuContext.Provider value={value}>
@@ -359,7 +357,19 @@ export const ActionsMenuBody = ({
             root={getFloatingUiRootElement(actionMenu.refs.reference)}
           >
             <FloatingFocusManager context={actionMenu.context} modal={true}>
-              {ActionMenuContent}
+              <StyledActionsMenuContainer
+                {...sharedContentProps}
+                ref={ref}
+                style={{
+                  ...actionMenu.floatingStyles,
+                  zIndex: getFloatingUiZIndex(actionMenu.refs.reference)
+                }}
+                {...actionMenu.getFloatingProps(props)}
+              >
+                <Menu menuWidth={menuWidth} isOpen={toggleState}>
+                  {children}
+                </Menu>
+              </StyledActionsMenuContainer>
             </FloatingFocusManager>
           </FloatingPortal>
         ) : (
@@ -369,7 +379,14 @@ export const ActionsMenuBody = ({
           but in a hidden state ensures that tests pass. * Ideally, we would
           update all the tests in teamform-app-ui to open the ActionsMenu *
           before assertion. **/
-          ActionMenuContent
+          <StyledActionsMenuContainer
+            {...sharedContentProps}
+            className="actionMenu-content hack-for-legacy-tests"
+          >
+            <Menu menuWidth={menuWidth} isOpen={toggleState}>
+              {children}
+            </Menu>
+          </StyledActionsMenuContainer>
         )}
       </Wrapper>
     </ActionMenuContext.Provider>

--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -298,19 +298,31 @@ export const ActionsMenuBody = ({
   const triggerRef = useMergeRefs([actionMenu.refs.setReference, childrenRef]);
   const ref = useMergeRefs([actionMenu.refs.setFloating]);
 
-  const triggerProps = {
-    ariaLabel,
-    "aria-label": ariaLabel,
-    onFocus: onTriggerFocus,
-    id,
-    ...actionMenu.getReferenceProps({
-      ...props,
-      onClick: onToggle,
-      ref: triggerRef,
-      "data-state": actionMenu.open ? "open" : "closed",
-      "data-testid": dataTestId
-    })
-  };
+  const triggerProps = useMemo(
+    () => ({
+      ariaLabel,
+      "aria-label": ariaLabel,
+      onFocus: onTriggerFocus,
+      id,
+      ...actionMenu.getReferenceProps({
+        ...props,
+        onClick: onToggle,
+        ref: triggerRef,
+        "data-state": actionMenu.open ? "open" : "closed",
+        "data-testid": dataTestId
+      })
+    }),
+    [
+      ariaLabel,
+      onTriggerFocus,
+      id,
+      actionMenu,
+      onToggle,
+      props,
+      triggerRef,
+      dataTestId
+    ]
+  );
 
   let triggerComponent = (
     <Control {...triggerProps}>
@@ -338,15 +350,20 @@ export const ActionsMenuBody = ({
     [closeOnClick, closeMenu, id, actionMenu]
   );
 
-  const visible = actionMenu.context.open;
+  const visible = useMemo(
+    () => actionMenu.context.open,
+    [actionMenu.context.open]
+  );
 
-  const sharedContentProps = {
-    "aria-labelledby": actionMenu.labelId,
-    className: `actionMenu-content ${visible ? "visible" : ""}`,
-    "aria-hidden": visible ? "false" : "true",
-    "data-testid": `${dataTestId}__menu`
-  };
+  const sharedContentProps = useMemo(
+    () => ({
+      "aria-labelledby": actionMenu.labelId,
+      "data-testid": `${dataTestId}__menu`
+    }),
+    [actionMenu.labelId, dataTestId]
+  );
 
+  console.log("visible", visible, props);
   const component = (
     <ActionMenuContext.Provider value={value}>
       <Wrapper {...props}>
@@ -359,12 +376,14 @@ export const ActionsMenuBody = ({
             <FloatingFocusManager context={actionMenu.context} modal={true}>
               <StyledActionsMenuContainer
                 {...sharedContentProps}
-                ref={ref}
+                {...actionMenu.getFloatingProps(props)}
                 style={{
                   ...actionMenu.floatingStyles,
                   zIndex: getFloatingUiZIndex(actionMenu.refs.reference)
                 }}
-                {...actionMenu.getFloatingProps(props)}
+                className="actionMenu-content visible"
+                aria-hidden="false"
+                ref={ref}
               >
                 <Menu menuWidth={menuWidth} isOpen={toggleState}>
                   {children}

--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -358,6 +358,15 @@ export const ActionsMenuBody = ({
     [actionMenu.floatingStyles, actionMenu.refs.reference]
   );
 
+  const menuDataTestId = useMemo(() => `${dataTestId}__menu`, [dataTestId]);
+
+  const { getFloatingProps } = actionMenu;
+
+  const floatingProps = useMemo(
+    () => getFloatingProps(props),
+    [getFloatingProps, props]
+  );
+
   const component = (
     <ActionMenuContext.Provider value={value}>
       <Wrapper {...props}>
@@ -370,8 +379,8 @@ export const ActionsMenuBody = ({
             <FloatingFocusManager context={actionMenu.context} modal={true}>
               <StyledActionsMenuContainer
                 aria-labelledby={actionMenu.labelId}
-                data-testid={`${dataTestId}__menu`}
-                {...actionMenu.getFloatingProps(props)}
+                data-testid={menuDataTestId}
+                {...floatingProps}
                 style={style}
                 className="actionMenu-content visible"
                 aria-hidden="false"
@@ -392,7 +401,7 @@ export const ActionsMenuBody = ({
           before assertion. **/
           <StyledActionsMenuContainer
             aria-labelledby={actionMenu.labelId}
-            data-testid={`${dataTestId}__menu`}
+            data-testid={menuDataTestId}
             className="actionMenu-content hack-for-legacy-tests"
           >
             <Menu menuWidth={menuWidth} isOpen={toggleState}>

--- a/lib/components/Popover/index.js
+++ b/lib/components/Popover/index.js
@@ -356,26 +356,12 @@ export default function Popover({
     [context.placement, direction]
   );
 
-  const sharedStylePopoverProps = useMemo(
+  const style = useMemo(
     () => ({
-      textAlign,
-      width,
-      enableSelectAll,
-      ariaLabel
+      ...floatingStyles,
+      zIndex: getFloatingUiZIndex(context.refs.reference)
     }),
-    [textAlign, width, enableSelectAll, ariaLabel]
-  );
-
-  const floatingStyledPopoverProps = useMemo(
-    () => ({
-      className: `Tooltip popover visible ${directionClass}`,
-      ref: refs.setFloating,
-      style: {
-        ...floatingStyles,
-        zIndex: getFloatingUiZIndex(context.refs.reference)
-      }
-    }),
-    [context.refs.reference, directionClass, floatingStyles, refs.setFloating]
+    [floatingStyles, context.refs.reference]
   );
 
   const containsLinks = refs.floating?.current?.querySelectorAll("a").length;
@@ -412,18 +398,28 @@ export default function Popover({
                 }
               >
                 <StyledPopover
-                  {...sharedStylePopoverProps}
+                  className={`Tooltip popover visible ${directionClass}`}
+                  ref={refs.setFloating}
+                  textAlign={textAlign}
+                  width={width}
+                  enableSelectAll={enableSelectAll}
+                  ariaLabel={ariaLabel}
+                  style={style}
                   {...getFloatingProps()}
-                  {...floatingStyledPopoverProps}
                 >
                   {text}
                 </StyledPopover>
               </FloatingFocusManager>
             ) : (
               <StyledPopover
-                {...sharedStylePopoverProps}
+                className={`Tooltip popover visible ${directionClass}`}
+                ref={refs.setFloating}
+                textAlign={textAlign}
+                width={width}
+                enableSelectAll={enableSelectAll}
+                ariaLabel={ariaLabel}
+                style={style}
                 {...getFloatingProps()}
-                {...floatingStyledPopoverProps}
               >
                 {text}
               </StyledPopover>
@@ -438,8 +434,8 @@ export default function Popover({
            * before assertion.
            **/
           <StyledPopover
+            ariaLabel={ariaLabel}
             className={`Tooltip popover ${directionClass} hack-for-legacy-tests`}
-            {...sharedStylePopoverProps}
           >
             {text}
           </StyledPopover>

--- a/lib/components/Popover/index.js
+++ b/lib/components/Popover/index.js
@@ -79,9 +79,15 @@ const StyledPopover = styled.div`
   box-shadow: ${themeGet("shadows.boxDefault")};
   user-select: ${(props) => (props.enableSelectAll ? "all" : "auto")};
 
-  pointer-events: none;
-  opacity: 0;
-  visibility: hidden;
+  &.hack-for-legacy-tests {
+    position: absolute;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    height: 0;
+    width: 0;
+    padding: 0;
+  }
 
   &.visible {
     opacity: 1;
@@ -267,6 +273,28 @@ const StyledPopover = styled.div`
   }
 `;
 
+// const PopoverContent = () => {
+//   return (
+//     <StyledPopover
+//       textAlign={textAlign}
+//       width={width}
+//       enableSelectAll={enableSelectAll}
+//       className={`Tooltip popover ${
+//         visible ? "visible" : ""
+//       } ${directionClass}`}
+//       ref={refs.setFloating}
+//       style={{
+//         ...floatingStyles,
+//         zIndex: getFloatingUiZIndex(context.refs.reference)
+//       }}
+//       {...getFloatingProps()}
+//       ariaLabel={ariaLabel}
+//     >
+//       {text}
+//     </StyledPopover>
+//   );
+// };
+
 export default function Popover({
   children,
   direction = "right",
@@ -322,25 +350,24 @@ export default function Popover({
       ? direction
       : context.placement;
 
-  const Popover = (
-    <StyledPopover
-      textAlign={textAlign}
-      width={width}
-      enableSelectAll={enableSelectAll}
-      className={`Tooltip popover ${
-        visible ? "visible" : ""
-      } ${directionClass}`}
-      ref={refs.setFloating}
-      style={{
-        ...floatingStyles,
-        zIndex: getFloatingUiZIndex(context.refs.reference)
-      }}
-      {...getFloatingProps()}
-      ariaLabel={ariaLabel}
-    >
-      {text}
-    </StyledPopover>
-  );
+  const sharedStylePopoverProps = {
+    textAlign,
+    width,
+    enableSelectAll,
+    ariaLabel
+  };
+
+  const floatingStyledPopoverProps = {
+    className: `Tooltip popover visible ${directionClass}`,
+    ref: refs.setFloating,
+    style: {
+      ...floatingStyles,
+      zIndex: getFloatingUiZIndex(context.refs.reference)
+    },
+    ...getFloatingProps(),
+    ...sharedStylePopoverProps
+  };
+
   const containsLinks = refs.floating?.current?.querySelectorAll("a").length;
 
   return (
@@ -374,14 +401,17 @@ export default function Popover({
                   isRenderedInReactSelectMenu(context.refs.reference) && -1
                 }
               >
-                {Popover}
+                <StyledPopover {...floatingStyledPopoverProps}>
+                  {text}
+                </StyledPopover>
               </FloatingFocusManager>
             ) : (
-              Popover
+              <StyledPopover {...floatingStyledPopoverProps}>
+                {text}
+              </StyledPopover>
             )}
           </FloatingPortal>
         ) : (
-          Popover
           /*
            * HACK: Fixing all the broken tests in teamform-app-ui is too time consuming
            * right this moment with a lot of the tests asserting against Popover items.
@@ -389,6 +419,12 @@ export default function Popover({
            * Ideally, we would update all the tests in teamform-app-ui to open the Popover
            * before assertion.
            **/
+          <StyledPopover
+            className={`Tooltip popover ${directionClass} hack-for-legacy-tests`}
+            {...sharedStylePopoverProps}
+          >
+            {text}
+          </StyledPopover>
         ))}
 
       {children}

--- a/lib/components/Popover/index.js
+++ b/lib/components/Popover/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import {
   useFloating,
   autoUpdate,
@@ -340,33 +340,43 @@ export default function Popover({
     role
   ]);
 
-  const triggerProps = {
-    ...getReferenceProps({ ref: refs.setReference }),
-    tabIndex: "0"
-  };
+  const triggerProps = useMemo(
+    () => ({
+      ...getReferenceProps({ ref: refs.setReference }),
+      tabIndex: "0"
+    }),
+    [getReferenceProps, refs.setReference]
+  );
 
-  const directionClass =
-    context.placement === DIRECTIONS_MAP[direction]
-      ? direction
-      : context.placement;
+  const directionClass = useMemo(
+    () =>
+      context.placement === DIRECTIONS_MAP[direction]
+        ? direction
+        : context.placement,
+    [context.placement, direction]
+  );
 
-  const sharedStylePopoverProps = {
-    textAlign,
-    width,
-    enableSelectAll,
-    ariaLabel
-  };
+  const sharedStylePopoverProps = useMemo(
+    () => ({
+      textAlign,
+      width,
+      enableSelectAll,
+      ariaLabel
+    }),
+    [textAlign, width, enableSelectAll, ariaLabel]
+  );
 
-  const floatingStyledPopoverProps = {
-    className: `Tooltip popover visible ${directionClass}`,
-    ref: refs.setFloating,
-    style: {
-      ...floatingStyles,
-      zIndex: getFloatingUiZIndex(context.refs.reference)
-    },
-    ...getFloatingProps(),
-    ...sharedStylePopoverProps
-  };
+  const floatingStyledPopoverProps = useMemo(
+    () => ({
+      className: `Tooltip popover visible ${directionClass}`,
+      ref: refs.setFloating,
+      style: {
+        ...floatingStyles,
+        zIndex: getFloatingUiZIndex(context.refs.reference)
+      }
+    }),
+    [context.refs.reference, directionClass, floatingStyles, refs.setFloating]
+  );
 
   const containsLinks = refs.floating?.current?.querySelectorAll("a").length;
 
@@ -401,12 +411,20 @@ export default function Popover({
                   isRenderedInReactSelectMenu(context.refs.reference) && -1
                 }
               >
-                <StyledPopover {...floatingStyledPopoverProps}>
+                <StyledPopover
+                  {...sharedStylePopoverProps}
+                  {...getFloatingProps()}
+                  {...floatingStyledPopoverProps}
+                >
                   {text}
                 </StyledPopover>
               </FloatingFocusManager>
             ) : (
-              <StyledPopover {...floatingStyledPopoverProps}>
+              <StyledPopover
+                {...sharedStylePopoverProps}
+                {...getFloatingProps()}
+                {...floatingStyledPopoverProps}
+              >
                 {text}
               </StyledPopover>
             )}

--- a/lib/components/Popover/index.js
+++ b/lib/components/Popover/index.js
@@ -273,28 +273,6 @@ const StyledPopover = styled.div`
   }
 `;
 
-// const PopoverContent = () => {
-//   return (
-//     <StyledPopover
-//       textAlign={textAlign}
-//       width={width}
-//       enableSelectAll={enableSelectAll}
-//       className={`Tooltip popover ${
-//         visible ? "visible" : ""
-//       } ${directionClass}`}
-//       ref={refs.setFloating}
-//       style={{
-//         ...floatingStyles,
-//         zIndex: getFloatingUiZIndex(context.refs.reference)
-//       }}
-//       {...getFloatingProps()}
-//       ariaLabel={ariaLabel}
-//     >
-//       {text}
-//     </StyledPopover>
-//   );
-// };
-
 export default function Popover({
   children,
   direction = "right",
@@ -366,6 +344,16 @@ export default function Popover({
 
   const containsLinks = refs.floating?.current?.querySelectorAll("a").length;
 
+  const visiblePopoverClassName = useMemo(
+    () => `Tooltip popover visible ${directionClass}`,
+    [directionClass]
+  );
+
+  const floatingProps = useMemo(
+    () => getFloatingProps(props),
+    [getFloatingProps, props]
+  );
+
   return (
     <Container
       inlineBlock={inlineBlock}
@@ -398,28 +386,28 @@ export default function Popover({
                 }
               >
                 <StyledPopover
-                  className={`Tooltip popover visible ${directionClass}`}
+                  className={visiblePopoverClassName}
                   ref={refs.setFloating}
                   textAlign={textAlign}
                   width={width}
                   enableSelectAll={enableSelectAll}
                   ariaLabel={ariaLabel}
                   style={style}
-                  {...getFloatingProps()}
+                  {...floatingProps}
                 >
                   {text}
                 </StyledPopover>
               </FloatingFocusManager>
             ) : (
               <StyledPopover
-                className={`Tooltip popover visible ${directionClass}`}
+                className={visiblePopoverClassName}
                 ref={refs.setFloating}
                 textAlign={textAlign}
                 width={width}
                 enableSelectAll={enableSelectAll}
                 ariaLabel={ariaLabel}
                 style={style}
-                {...getFloatingProps()}
+                {...floatingProps}
               >
                 {text}
               </StyledPopover>
@@ -435,7 +423,7 @@ export default function Popover({
            **/
           <StyledPopover
             ariaLabel={ariaLabel}
-            className={`Tooltip popover ${directionClass} hack-for-legacy-tests`}
+            className="Tooltip popover hack-for-legacy-tests"
           >
             {text}
           </StyledPopover>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orcs-design-system",
-  "version": "3.2.36",
+  "version": "3.2.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orcs-design-system",
-      "version": "3.2.36",
+      "version": "3.2.37",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orcs-design-system",
-  "version": "3.2.36",
+  "version": "3.2.37",
   "engines": {
     "node": "20.12.2"
   },


### PR DESCRIPTION
## What this PR does, and why

> To get around a huge task of fixing tests in `teamform-app-ui` we rendered a "ghost" component to be asserted against. I originally added the floating-ui props to this component. This PR removes those props to prevent recalculations of layout.
