### PR TITLE
fix: extra space for Action menu

### DIFF
--- a/lib/components/ActionsMenu/index.js
+++ b/lib/components/ActionsMenu/index.js
@@ -71,11 +71,15 @@ const StyledActionsMenuContainer = styled.div`
   &.hack-for-legacy-tests {
     position: absolute;
     pointer-events: none;
-    opacity: 0;
-    visibility: hidden;
-    height: 0;
-    width: 0;
+    width: 1px;
+    height: 1px;
     padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border-width: 0;
   }
 
   &.visible {


### PR DESCRIPTION
## What this PR does, and why
There is an extra space for the Action menu if using the current styles for test.
Can change to the sr-only kind of style without any space

Current:
![Screenshot 2024-09-05 at 11 03 19 PM](https://github.com/user-attachments/assets/1aa9ebd5-adad-4d2e-ba3e-57c4463ffcdd)

After fix:
![Screenshot 2024-09-05 at 10 58 46 PM](https://github.com/user-attachments/assets/0b088019-7089-4600-8e79-82ab01411eea)

> Add an explanation of what the code in this PR does. Add screenshot/screencapture and jira link where necessary.
