### PR TITLE
Floating panels update

### DIFF
--- a/lib/components/FloatingPanels/FloatingPanels.styles.js
+++ b/lib/components/FloatingPanels/FloatingPanels.styles.js
@@ -1,13 +1,14 @@
 import styled from "styled-components";
 import { themeGet } from "@styled-system/theme-get";
 
-export const Container = styled.div`
+const panelWidth = "300px";
+export const ComponentContainer = styled.div`
   z-index: 2;
   position: absolute;
   display: flex;
   flex-direction: column;
+  align-items: flex-end;
   gap: 8px;
-  width: 300px;
   max-height: ${({ containerHeight }) =>
     containerHeight ? `${containerHeight}px` : "100%"};
   ${({ position }) =>
@@ -20,41 +21,48 @@ export const Container = styled.div`
       .join("\n")}
 `;
 
+export const PanelContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  gap: 8px;
+  border-radius: calc(${themeGet("radii.2")} + 1px);
+  overflow: hidden;
+  background: transparent;
+  width: ${panelWidth};
+  max-height: ${({ containerHeight }) =>
+    containerHeight ? `${containerHeight}px` : "100%"};
+`;
+
 export const PanelWrapper = styled.div`
+  display: ${({ isExpanded }) => (isExpanded ? "block" : "none")};
   background: white;
-  border: ${({ isExpanded, theme }) =>
-    isExpanded ? `1px solid ${theme.colors.greyLighter}` : "1px solid white"};
+  width: ${panelWidth};
+  border: 1px solid ${themeGet("colors.greyLighter")};
   border-radius: 8px;
   border-radius: 0 0 8px 8px;
-  box-shadow: ${({ isExpanded }) =>
-    isExpanded ? "0 1px 3px rgba(0, 0, 0, 0.1)" : "none"};
-  overflow-y: ${({ isExpanded }) => (isExpanded ? "auto" : "hidden")};
-  // min-height: 48px;
-  padding: ${({ isExpanded }) => (isExpanded ? "0 12px 12px 12px" : "0 12px")};
-  margin-top: 46px;
-  max-height: ${({ isExpanded }) => (isExpanded ? "none" : "0")};
+  overflow-y: auto;
+  padding: "0 12px 12px 12px";
+  margin-top: 37px;
   transition: max-height 0.3s ease-in-out;
 `;
 
 export const PanelHeader = styled.button`
   font-family: ${themeGet("fonts.main")};
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.1);
   color: ${themeGet("colors.greyDarkest")};
-  width: 100%;
-  margin-left: -13px;
-  margin-top: -46px;
-  border-radius: ${({ isExpanded }) => (isExpanded ? "8px 8px 0 0" : "8px")};
+  margin-left: -1px;
+  margin-top: -37px;
+  border-radius: 8px 8px 0 0;
   appearance: none;
   background-color: white;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 12px 12px 12px;
-  height: 46px;
+  padding: ${themeGet("space.s")};
+  height: 37px;
   position: absolute;
-  width: 300px;
-  border-bottom: ${({ isExpanded, theme }) =>
-    isExpanded ? `1px solid ${theme.colors.greyLighter}` : "none"};
+  width: ${panelWidth};
   border: solid 1px ${themeGet("colors.greyLighter")};
   z-index: 1;
   cursor: pointer;
@@ -76,24 +84,39 @@ export const Title = styled.span`
   font-weight: 500;
 `;
 
-export const IconWrapper = styled.div`
-  background-color: ${themeGet("colors.primary")};
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
+export const PanelBar = styled.div`
   display: flex;
-  align-items: center;
-  justify-content: center;
+  background: white;
+  border: 1px solid ${themeGet("colors.greyLighter")};
+  border-radius: ${themeGet("radii.2")};
+  padding: 2px;
+  gap: 2px;
+  height: fit-content;
+  box-shadow: 0 0 1px 2px rgba(255, 255, 255, 1);
 `;
 
-export const ChevronWrapper = styled(IconWrapper)`
-  transition: background-color 0.3s ease-in-out;
-  background-color: ${({ isHovered }) =>
-    isHovered ? themeGet("colors.greyLighter") : "white"};
+export const IconButton = styled.button`
+  font-family: ${themeGet("fonts.main")};
+  appearance: none;
+  background-color: ${({ isExpanded }) =>
+    isExpanded ? themeGet("colors.primaryLightest") : themeGet("colors.white")};
+  border: none;
+  width: 36px;
+  cursor: pointer;
+  height: 36px;
+  display: flex;
+  border-radius: ${themeGet("radii.2")};
+  align-items: center;
+  justify-content: center;
+  transition: ${themeGet("transition.transitionDefault")};
+  &:hover {
+    background-color: ${themeGet("colors.primaryLightest")};
+  }
 `;
 
 export const PanelContent = styled.div`
-  padding-top: 12px;
+  padding: ${themeGet("space.s")};
+  width: inerhit;
   display: ${({ isExpanded }) => (isExpanded ? "block" : "none")};
   height: ${({ isExpanded }) => (isExpanded ? "100%" : "0")};
   opacity: ${({ isExpanded }) => (isExpanded ? "1" : "0")};

--- a/lib/components/FloatingPanels/Panel.js
+++ b/lib/components/FloatingPanels/Panel.js
@@ -2,45 +2,47 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 
 import Icon from "../Icon";
+import Popover from "../Popover";
 import {
   PanelWrapper,
   PanelHeader,
   HeaderContent,
   Title,
-  IconWrapper,
-  ChevronWrapper,
+  IconButton,
   PanelContent
 } from "./FloatingPanels.styles";
 
-const Panel = ({
+export const Panel = ({
   iconName,
   title,
   containerHeight,
   content,
-  defaultExpanded = false
+  isExpanded,
+  toggleExpanded
 }) => {
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
-  const arrowIcon = isExpanded ? "chevron-up" : "chevron-down";
   const [isHovered, setIsHovered] = useState(false);
   return (
     <PanelWrapper containerHeight={containerHeight} isExpanded={isExpanded}>
       <PanelHeader
-        onClick={() => setIsExpanded(!isExpanded)}
-        isExpanded={isExpanded}
+        onClick={toggleExpanded}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
         onFocus={() => setIsHovered(true)}
         onBlur={() => setIsHovered(false)}
       >
         <HeaderContent>
-          <IconWrapper>
-            <Icon size="xs" color="white" icon={["far", iconName]} />
-          </IconWrapper>
-          <Title>{title}</Title>
+          <Icon size="s" color="greyDarker" icon={["far", iconName]} />
+          {isExpanded && <Title>{title}</Title>}
         </HeaderContent>
-        <ChevronWrapper isHovered={isHovered}>
-          <Icon size="sm" icon={["fas", arrowIcon]} color="greyDarker" />
-        </ChevronWrapper>
+        {isExpanded && (
+          <Popover direction="left" text="Close panel" width="fit-content">
+            <Icon
+              size="sm"
+              icon={["fas", "times"]}
+              color={isHovered ? "primary" : "greyDarker"}
+            />
+          </Popover>
+        )}
       </PanelHeader>
       <PanelContent isExpanded={isExpanded}>{content}</PanelContent>
     </PanelWrapper>
@@ -53,11 +55,32 @@ Panel.propTypes = {
   content: PropTypes.node.isRequired,
   defaultExpanded: PropTypes.bool,
   containerHeight: PropTypes.number,
-  isExpanded: PropTypes.bool.isRequired
+  isExpanded: PropTypes.bool.isRequired,
+  toggleExpanded: PropTypes.func.isRequired
 };
 
 Panel.defaultProps = {
   defaultExpanded: false
 };
 
-export default Panel;
+export const PanelBarIcon = ({
+  iconName,
+  title,
+  toggleExpanded,
+  isExpanded
+}) => {
+  return (
+    <Popover direction="top" text={title} width="fit-content">
+      <IconButton onClick={toggleExpanded} isExpanded={isExpanded}>
+        <Icon size="s" color="greyDarker" icon={["far", iconName]} />
+      </IconButton>
+    </Popover>
+  );
+};
+
+PanelBarIcon.propTypes = {
+  iconName: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  toggleExpanded: PropTypes.func.isRequired,
+  isExpanded: PropTypes.bool.isRequired
+};

--- a/lib/components/FloatingPanels/index.js
+++ b/lib/components/FloatingPanels/index.js
@@ -1,6 +1,10 @@
-import React from "react";
-import { Container } from "./FloatingPanels.styles";
-import Panel from "./Panel";
+import React, { useState, useEffect } from "react";
+import {
+  ComponentContainer,
+  PanelContainer,
+  PanelBar
+} from "./FloatingPanels.styles";
+import { Panel, PanelBarIcon } from "./Panel";
 import PropTypes from "prop-types";
 
 const FloatingPanels = ({
@@ -8,12 +12,44 @@ const FloatingPanels = ({
   containerHeight,
   position = { right: 20, top: 20 }
 }) => {
+  const [expandedPanelId, setExpandedPanelId] = useState(null);
+
+  // Set the default expanded panel on component mount
+  useEffect(() => {
+    const defaultExpandedPanel = panels.find((panel) => panel.defaultExpanded);
+    if (defaultExpandedPanel) {
+      setExpandedPanelId(defaultExpandedPanel.id);
+    }
+  }, [panels]);
+
+  const togglePanel = (panelId) => {
+    setExpandedPanelId(expandedPanelId === panelId ? null : panelId);
+  };
   return (
-    <Container containerHeight={containerHeight} position={position}>
-      {panels.map((panel) => (
-        <Panel key={panel?.id} {...panel} containerHeight={containerHeight} />
-      ))}
-    </Container>
+    <ComponentContainer containerHeight={containerHeight} position={position}>
+      <PanelBar>
+        {panels.map((panel) => (
+          <PanelBarIcon
+            key={panel?.id}
+            iconName={panel.iconName}
+            title={panel.title}
+            isExpanded={expandedPanelId === panel.id}
+            toggleExpanded={() => togglePanel(panel.id)}
+          />
+        ))}
+      </PanelBar>
+      <PanelContainer containerHeight={containerHeight}>
+        {panels.map((panel) => (
+          <Panel
+            key={panel?.id}
+            {...panel}
+            containerHeight={containerHeight}
+            isExpanded={expandedPanelId === panel.id}
+            toggleExpanded={() => togglePanel(panel.id)}
+          />
+        ))}
+      </PanelContainer>
+    </ComponentContainer>
   );
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orcs-design-system",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orcs-design-system",
-      "version": "3.3.8",
+      "version": "3.3.9",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orcs-design-system",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "engines": {
     "node": "20.12.2"
   },


### PR DESCRIPTION
Updates Floating panels UI and behaviour to be a bit cleaner and more in line with Lucy's cosmos mocks. This new approach will also eliminate issues with panel heights and scroll seeing as we are adding more content here in the app.

Before:
<img width="330" alt="Screenshot 2025-02-25 at 10 29 13 am" src="https://github.com/user-attachments/assets/a15a3ac9-9116-47b5-b7ab-f544aa972012" />


After:
<img width="319" alt="Screenshot 2025-02-25 at 10 16 49 am" src="https://github.com/user-attachments/assets/bf8304a9-7c4a-4f50-9728-24918022be25" />


