### PR TITLE
Chore/rename a prop default expanded to expanded

### DIFF
--- a/lib/components/FloatingPanels/FloatingPanels.mdx
+++ b/lib/components/FloatingPanels/FloatingPanels.mdx
@@ -25,14 +25,13 @@ const panels = [
     id: "legend",
     iconName: "map",
     title: "Legend",
-    defaultExpanded: true,
+    expanded: true,
     content: <div>Legend content goes here</div>
   },
   {
     id: "view-options",
     iconName: "eye",
     title: "View Options",
-    defaultExpanded: true,
     content: <div>View options content goes here</div>
   },
   {

--- a/lib/components/FloatingPanels/FloatingPanels.stories.js
+++ b/lib/components/FloatingPanels/FloatingPanels.stories.js
@@ -49,7 +49,7 @@ const panels = [
     id: "view-options",
     iconName: "eye",
     title: "View Options",
-    defaultExpanded: true,
+    expanded: true,
     content: <Properties />
   },
   {

--- a/lib/components/FloatingPanels/index.js
+++ b/lib/components/FloatingPanels/index.js
@@ -15,11 +15,10 @@ const FloatingPanels = ({
 }) => {
   const [expandedPanelId, setExpandedPanelId] = useState(null);
 
-  // Set the default expanded panel on component mount
   useEffect(() => {
-    const defaultExpandedPanel = panels.find((panel) => panel.defaultExpanded);
-    if (defaultExpandedPanel) {
-      setExpandedPanelId(defaultExpandedPanel.id);
+    const expandedPanel = panels.find((panel) => panel.expanded);
+    if (expandedPanel?.id) {
+      setExpandedPanelId(expandedPanel.id);
     }
   }, [panels]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "orcs-design-system",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orcs-design-system",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "engines": {
     "node": "20.12.2"
   },


### PR DESCRIPTION
## What this PR does, and why

> Add an explanation of what the code in this PR does. Add screenshot/screencapture and jira link where necessary.

Rename `defaultExpanded` to `expanded`, `useEffect` listens `panels` array changes and it re-renders. its not one time execution on mount. name `expanded` is a bit clearer