### PR TITLE
update floating panels component to reuse as control

### DIFF
--- a/lib/components/FloatingPanels/FloatingPanels.mdx
+++ b/lib/components/FloatingPanels/FloatingPanels.mdx
@@ -6,7 +6,10 @@ import * as stories from "./FloatingPanels.stories";
 
 # Floating Panels
 
-The Floating Panels Component is a flexible React component that creates a set of collapsible panels floating on the screen. It's ideal for displaying information or controls that need to be easily accessible but not always visible.
+The Floating Panels Component is a flexible React component that can be used in two different ways.
+
+1. Creates a set of collapsible panels floating on the screen. It's ideal for displaying information or controls that need to be easily accessible but not always visible.
+2. Can be used as a control panel for actions, where instead of a set of collapsible panels, it's a single panel with a set of actions.
 
 ## Features
 
@@ -18,6 +21,10 @@ The Floating Panels Component is a flexible React component that creates a set o
 - Ability to include any content within panels (can pass content as a component)
 
 ## Usage
+
+## Floating Panels as a set of collapsible panels
+
+#### For floating togglable pop out panels. You can define the panels you want to display, like so:
 
 ```js run
 const panels = [
@@ -51,6 +58,12 @@ const panels = [
 ```
 
 <Canvas of={stories.defaultFloatingPanels} />
+
+## Floating Panels as a control panel
+
+#### For a control panel, you can define the actions you want to display, like so:
+
+<Canvas of={stories.floatingActionsPanel} />
 
 ## Properties
 

--- a/lib/components/FloatingPanels/FloatingPanels.stories.js
+++ b/lib/components/FloatingPanels/FloatingPanels.stories.js
@@ -13,7 +13,6 @@ library.add(far);
 
 export default {
   title: "Components/FloatingPanels",
-  decorators: [(storyFn) => <Box minHeight="600px">{storyFn()}</Box>],
   component: FloatingPanels
 };
 const Properties = () => {
@@ -83,11 +82,13 @@ const createPanels = (shouldUseAsControl = true) => {
 
 export const defaultFloatingPanels = () => {
   return (
-    <FloatingPanels
-      panels={createPanels()}
-      containerHeight={500}
-      position={{ right: 20, top: 20 }}
-    />
+    <Box minHeight="600px">
+      <FloatingPanels
+        panels={createPanels()}
+        containerHeight={500}
+        position={{ right: 20, top: 20 }}
+      />
+    </Box>
   );
 };
 
@@ -97,8 +98,8 @@ export const floatingActionsPanel = () => {
   return (
     <FloatingPanels
       panels={createPanels(false)}
-      containerHeight={500}
-      position={{ right: 20, top: 20 }}
+      position={{ bottom: 10 }}
+      centered={true}
       onClick={(panelId) => alert(`Panel ${panelId} clicked`)}
     />
   );

--- a/lib/components/FloatingPanels/FloatingPanels.stories.js
+++ b/lib/components/FloatingPanels/FloatingPanels.stories.js
@@ -74,8 +74,10 @@ const createPanels = (shouldUseAsControl = true) => {
 
   return panels.map((panel) => ({
     ...panel,
+    expanded: panel.id === "person-details" ? true : false,
     content: null,
-    noActiveState: true
+    stopToggling: panel.id === "view-options" ? false : true,
+    noActiveState: panel.id === "view-options" ? true : false
   }));
 };
 

--- a/lib/components/FloatingPanels/FloatingPanels.stories.js
+++ b/lib/components/FloatingPanels/FloatingPanels.stories.js
@@ -44,32 +44,45 @@ const Properties = () => {
     </>
   );
 };
-const panels = [
-  {
-    id: "view-options",
-    iconName: "eye",
-    title: "View Options",
-    expanded: true,
-    content: <Properties />
-  },
-  {
-    id: "properties",
-    iconName: "sun",
-    title: "Properties",
-    content: <Properties />
-  },
-  {
-    id: "person-details",
-    iconName: "user",
-    title: "Person Details",
-    content: <Properties />
+
+const createPanels = (shouldUseAsControl = true) => {
+  const panels = [
+    {
+      id: "view-options",
+      iconName: "eye",
+      title: "View Options",
+      expanded: true,
+      content: <Properties />
+    },
+    {
+      id: "properties",
+      iconName: "sun",
+      title: "Properties",
+      content: <Properties />
+    },
+    {
+      id: "person-details",
+      iconName: "user",
+      title: "Person Details",
+      content: <Properties />
+    }
+  ];
+
+  if (shouldUseAsControl) {
+    return panels;
   }
-];
+
+  return panels.map((panel) => ({
+    ...panel,
+    content: null,
+    noActiveState: true
+  }));
+};
 
 export const defaultFloatingPanels = () => {
   return (
     <FloatingPanels
-      panels={panels}
+      panels={createPanels()}
       containerHeight={500}
       position={{ right: 20, top: 20 }}
     />
@@ -77,3 +90,16 @@ export const defaultFloatingPanels = () => {
 };
 
 defaultFloatingPanels.storyName = "Default Floating Panels";
+
+export const floatingActionsPanel = () => {
+  return (
+    <FloatingPanels
+      panels={createPanels(false)}
+      containerHeight={500}
+      position={{ right: 20, top: 20 }}
+      onClick={(panelId) => alert(`Panel ${panelId} clicked`)}
+    />
+  );
+};
+
+floatingActionsPanel.storyName = "Floating Panels as Controls";

--- a/lib/components/FloatingPanels/FloatingPanels.styles.js
+++ b/lib/components/FloatingPanels/FloatingPanels.styles.js
@@ -19,6 +19,14 @@ export const ComponentContainer = styled.div`
           `${key}: ${typeof value === "number" ? `${value}px` : value};`
       )
       .join("\n")}
+  ${({ centered }) =>
+    centered
+      ? `
+      left: 50%;
+      transform: translateX(-50%);
+      right: auto;
+    `
+      : ""}
 `;
 
 export const PanelContainer = styled.div`

--- a/lib/components/FloatingPanels/Panel.js
+++ b/lib/components/FloatingPanels/Panel.js
@@ -21,6 +21,9 @@ export const Panel = ({
   toggleExpanded
 }) => {
   const [isHovered, setIsHovered] = useState(false);
+  if (!content) {
+    return null;
+  }
   return (
     <PanelWrapper containerHeight={containerHeight} isExpanded={isExpanded}>
       <PanelHeader

--- a/lib/components/FloatingPanels/index.js
+++ b/lib/components/FloatingPanels/index.js
@@ -17,21 +17,20 @@ const FloatingPanels = ({
   const [expandedPanelId, setExpandedPanelId] = useState(null);
 
   useEffect(() => {
-    const expandedPanel = panels.find(
-      (panel) => panel.expanded && !panel?.noActiveState
-    );
-    if (expandedPanel?.id) {
+    const expandedPanel = panels.find((panel) => panel.expanded);
+    if (expandedPanel?.id && !expandedPanel.noActiveState) {
       setExpandedPanelId(expandedPanel.id);
     }
   }, [panels]);
 
   const togglePanel = (panelId) => {
-    const shouldSetState = panels.find(
-      (panel) => panel.id === panelId && !panel?.noActiveState
-    );
-    const selectedPanelId = expandedPanelId === panelId ? null : panelId;
+    const selectedPanel = panels.find((panel) => panel.id === panelId);
+    if (selectedPanel?.stopToggling && expandedPanelId === panelId) {
+      return;
+    }
     onClick(panelId);
-    if (shouldSetState) {
+    const selectedPanelId = expandedPanelId === panelId ? null : panelId;
+    if (!selectedPanel.noActiveState) {
       setExpandedPanelId(selectedPanelId);
     }
   };

--- a/lib/components/FloatingPanels/index.js
+++ b/lib/components/FloatingPanels/index.js
@@ -11,24 +11,39 @@ const FloatingPanels = ({
   panels,
   containerHeight,
   position = { right: 20, top: 20 },
+  centered = false,
   onClick = () => {}
 }) => {
   const [expandedPanelId, setExpandedPanelId] = useState(null);
 
   useEffect(() => {
-    const expandedPanel = panels.find((panel) => panel.expanded);
+    const expandedPanel = panels.find(
+      (panel) => panel.expanded && !panel?.noActiveState
+    );
     if (expandedPanel?.id) {
       setExpandedPanelId(expandedPanel.id);
     }
   }, [panels]);
 
   const togglePanel = (panelId) => {
+    const shouldSetState = panels.find(
+      (panel) => panel.id === panelId && !panel?.noActiveState
+    );
     const selectedPanelId = expandedPanelId === panelId ? null : panelId;
-    onClick(selectedPanelId);
-    setExpandedPanelId(selectedPanelId);
+    onClick(panelId);
+    if (shouldSetState) {
+      setExpandedPanelId(selectedPanelId);
+    }
   };
+
+  const shouldDisplayPanelContainer = panels?.some((panel) => panel?.content);
+
   return (
-    <ComponentContainer containerHeight={containerHeight} position={position}>
+    <ComponentContainer
+      centered={centered}
+      containerHeight={containerHeight}
+      position={position}
+    >
       <PanelBar>
         {panels.map((panel) => (
           <PanelBarIcon
@@ -40,17 +55,19 @@ const FloatingPanels = ({
           />
         ))}
       </PanelBar>
-      <PanelContainer containerHeight={containerHeight}>
-        {panels.map((panel) => (
-          <Panel
-            key={panel?.id}
-            {...panel}
-            containerHeight={containerHeight}
-            isExpanded={expandedPanelId === panel.id}
-            toggleExpanded={() => togglePanel(panel.id)}
-          />
-        ))}
-      </PanelContainer>
+      {shouldDisplayPanelContainer && (
+        <PanelContainer containerHeight={containerHeight}>
+          {panels.map((panel) => (
+            <Panel
+              key={panel?.id}
+              {...panel}
+              containerHeight={containerHeight}
+              isExpanded={expandedPanelId === panel.id}
+              toggleExpanded={() => togglePanel(panel.id)}
+            />
+          ))}
+        </PanelContainer>
+      )}
     </ComponentContainer>
   );
 };
@@ -72,7 +89,8 @@ FloatingPanels.propTypes = {
     bottom: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     left: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
   }),
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  centered: PropTypes.bool
 };
 
 FloatingPanels.defaultProps = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orcs-design-system",
-  "version": "3.3.13",
+  "version": "3.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orcs-design-system",
-      "version": "3.3.13",
+      "version": "3.3.14",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orcs-design-system",
-  "version": "3.3.13",
+  "version": "3.3.14",
   "engines": {
     "node": "20.12.2"
   },


### PR DESCRIPTION
## What this PR does, and why

> Add an explanation of what the code in this PR does. Add screenshot/screencapture and jira link where necessary.

[https://teamform.atlassian.net/browse/TPP-1141](https://teamform.atlassian.net/browse/TPP-1141)

## Add three more props to Floating panels component
* `centered` makes the panel positioned in center
* `noActiveState` for panel object, when passed, toggling state is not tracked, so that background color is not set when clicked
* `stopToggling` for panel object, when passed, once an icon is clicked, reselecting the same icon doesn't change its state, the background color is persisted

https://github.com/user-attachments/assets/6e759a6a-df2f-4bf5-bccc-1615f3dee715

