### PR TITLE
better source formatting

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,6 +8,8 @@ import { default as systemtheme } from "../lib/systemtheme";
 import { default as systemThemeCollapsed } from "../lib/systemThemeCollapsed";
 import styled, { ThemeProvider } from "styled-components";
 import { get } from "lodash";
+import prettier from "prettier";
+import parserBabel from "prettier/parser-babel";
 
 library.add(far, fas);
 
@@ -113,7 +115,14 @@ export const parameters = {
   },
   docs: {
     container: DocsContainer,
-    page: DocsPage
+    page: DocsPage,
+    source: {
+      transform: (input) =>
+        prettier.format(input, {
+          parser: "babel",
+          plugins: [parserBabel]
+        }),
+    },
   },
   a11y: { disable: false },
   viewMode: "docs",


### PR DESCRIPTION
From

<img width="1015" alt="Screenshot 2025-03-27 at 12 49 25" src="https://github.com/user-attachments/assets/1f1f6976-ac7d-46e0-85ae-1b79f2f0bbc3" />

To

<img width="1009" alt="Screenshot 2025-03-27 at 12 49 48" src="https://github.com/user-attachments/assets/ee7671a1-8c29-41fa-a858-a92075bd9a85" />

Has the biggest impact on the new FloatingPanels docs
