### PR TITLE
fix: stop render FloatingFocusManager

### DIFF
--- a/lib/components/Popover/index.js
+++ b/lib/components/Popover/index.js
@@ -335,6 +335,7 @@ export default function Popover({
   variant,
   ariaLabel,
   inlineBlock,
+  withFocusControl = true,
   ...props
 }) {
   const [visible, setVisible] = useState(false);
@@ -396,7 +397,8 @@ export default function Popover({
     [floatingStyles, context.refs.reference]
   );
 
-  const containsLinks = refs.floating?.current?.querySelectorAll("a").length;
+  const containsLinks =
+    withFocusControl && refs.floating?.current?.querySelectorAll("a").length;
 
   const visiblePopoverClassName = useMemo(
     () => `Tooltip popover visible ${directionClass}`,
@@ -522,5 +524,7 @@ Popover.propTypes = {
   /** Provide an aria-label if text is not a string */
   ariaLabel: PropTypes.string,
   /** Provide a tab index for accessibilty, defaults to 0 */
-  tabIndex: PropTypes.number
+  tabIndex: PropTypes.number,
+  /** Render tooltip with focus control when there is link inside, defaults to true */
+  withFocusControl: PropTypes.bool
 };


### PR DESCRIPTION
## What this PR does, and why

this component is keeping previous floating element and got double tooltip in screen

![Screenshot 2025-06-05 at 10 12 24 pm](https://github.com/user-attachments/assets/96cfd3b0-2f8a-49ca-8f83-64fcb1e2d75c)
